### PR TITLE
Move and rotate stacked bricks as a rigid unit

### DIFF
--- a/src/__tests__/engine/utils.test.ts
+++ b/src/__tests__/engine/utils.test.ts
@@ -728,3 +728,86 @@ describe('generateInstanceId', () => {
     expect(id.startsWith('brick-')).toBe(true)
   })
 })
+
+// ============================================
+// computeRigidStackRotation / Translation
+// ============================================
+
+import {
+  computeRigidStackRotation,
+  computeRigidStackTranslation,
+  type StackPieceInput,
+} from '@/engine/utils'
+
+describe('computeRigidStackTranslation', () => {
+  it('translates each piece by (dx, dy) and updates world cells', () => {
+    const stack: StackPieceInput[] = [
+      { position: [2, 3], shape: 'unit', rotation: 0 },
+      { position: [3, 3], shape: 'unit', rotation: 0 },
+    ]
+    const out = computeRigidStackTranslation(stack, 1, -1)!
+    expect(out[0].position).toEqual([3, 2])
+    expect(out[0].rotation).toBe(0)
+    expect(out[0].cells).toEqual([[3, 2]])
+    expect(out[1].position).toEqual([4, 2])
+    expect(out[1].cells).toEqual([[4, 2]])
+  })
+})
+
+describe('computeRigidStackRotation', () => {
+  it('rotates a unit on top of a 1x3 horizontal so the upper stays glued to the bottom', () => {
+    // Bottom: 1x3 horizontal at (5,5) — cells (5,5),(6,5),(7,5)
+    // Top: 1x1 sitting on top of (7,5) (the right end)
+    const stack: StackPieceInput[] = [
+      { position: [5, 5], shape: 'tromino-I', rotation: 0 },
+      { position: [7, 5], shape: 'unit', rotation: 0 },
+    ]
+    const out = computeRigidStackRotation(stack)!
+
+    // Bottom rotates in place, anchor stays at (5,5), rotation 90.
+    expect(out[0].position).toEqual([5, 5])
+    expect(out[0].rotation).toBe(90)
+    expect(sortCoords(out[0].cells)).toEqual(sortCoords([[5, 5], [5, 6], [5, 7]]))
+
+    // Top brick was glued to (7,5) which after rotation moves to (5,5) — the
+    // top end of the now-vertical bottom.
+    expect(out[1].position).toEqual([5, 5])
+    expect(out[1].rotation).toBe(90)
+    expect(out[1].cells).toEqual([[5, 5]])
+  })
+
+  it('four 90° rotations return the stack to its original layout', () => {
+    const shapes = ['tromino-I', 'unit'] as const
+    let stack: StackPieceInput[] = [
+      { position: [5, 5], shape: shapes[0], rotation: 0 },
+      { position: [7, 5], shape: shapes[1], rotation: 0 },
+    ]
+    for (let i = 0; i < 4; i++) {
+      const out = computeRigidStackRotation(stack)!
+      stack = out.map((o, idx) => ({
+        position: o.position,
+        shape: shapes[idx],
+        rotation: o.rotation,
+      }))
+    }
+    expect(stack[0].position).toEqual([5, 5])
+    expect(stack[0].rotation).toBe(0)
+    expect(stack[1].position).toEqual([7, 5])
+    expect(stack[1].rotation).toBe(0)
+  })
+
+  it('preserves cell-set when bottom is a 2x2 (rotation symmetric)', () => {
+    // 2x2 (O-tetromino) at (5,5). Top brick at (6,5).
+    const stack: StackPieceInput[] = [
+      { position: [5, 5], shape: 'O-tetromino', rotation: 0 },
+      { position: [6, 5], shape: 'unit', rotation: 0 },
+    ]
+    const out = computeRigidStackRotation(stack)!
+
+    // 2x2 footprint is the same after rotation.
+    expect(sortCoords(out[0].cells)).toEqual(sortCoords([[5, 5], [6, 5], [5, 6], [6, 6]]))
+    // The top brick still sits on a cell of the bottom.
+    const bottomCellSet = new Set(out[0].cells.map(c => `${c[0]},${c[1]}`))
+    expect(bottomCellSet.has(`${out[1].cells[0][0]},${out[1].cells[0][1]}`)).toBe(true)
+  })
+})

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -316,6 +316,31 @@ function DragDropManager() {
     return puzzle?.inventory.find(b => b.id === selectedBrickId);
   }, [puzzle, selectedBrickId, selectedPlacedBrick]);
 
+  // The whole stack lifts together: selected brick + everything stacked above it.
+  // This mirrors what move/rotate apply to.
+  const selectedStackIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!selectedPlacedBrick) return ids;
+    ids.add(selectedPlacedBrick.instanceId);
+
+    const visit = (target: typeof selectedPlacedBrick) => {
+      const targetCells = getBrickCells(target);
+      const targetSet = new Set(targetCells.map(([x, y]) => `${x},${y}`));
+      const targetZ = target.z || 0;
+      for (const b of boardState.placedBricks) {
+        if (ids.has(b.instanceId)) continue;
+        if ((b.z || 0) <= targetZ) continue;
+        const cells = getBrickCells(b);
+        if (cells.some(([x, y]) => targetSet.has(`${x},${y}`))) {
+          ids.add(b.instanceId);
+          visit(b);
+        }
+      }
+    };
+    visit(selectedPlacedBrick);
+    return ids;
+  }, [selectedPlacedBrick, boardState.placedBricks]);
+
   // Calculate z-level for ghost preview (for stacking)
   const ghostZLevel = useMemo(() => {
     if (!selectedInventoryBrick || !hoveredCell) return 0;
@@ -526,14 +551,14 @@ function DragDropManager() {
         // - No placed brick is selected (normal state - can select any brick)
         // When a placed brick is selected for moving, ALL bricks (including the selected one) 
         // become non-interactive so clicks pass through to the board for movement
-        const isThisBrickSelected = selectedBrickId === brick.instanceId;
+        const isThisBrickInSelectedStack = selectedStackIds.has(brick.instanceId);
         const isInteractive = !selectedInventoryBrick && !selectedPlacedBrick;
 
         return (
           <PolyominoBrick
             key={brick.instanceId}
             brick={brick}
-            isSelected={isThisBrickSelected}
+            isSelected={isThisBrickInSelectedStack}
             interactive={isInteractive}
             boardOffset={boardOffset}
             onSelect={() => handleBrickSelect(brick.instanceId)}

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -9,7 +9,7 @@
 
 import { useMemo, useCallback, useEffect, useState, useRef } from 'react';
 import type { UsePuzzleEngineReturn } from '../../engine';
-import { getValidSlideDestinations } from '../../engine';
+import { getValidSlideDestinations, findPiecesStackedOnTop } from '../../engine';
 import { SCENE_2D } from '../../config/sceneConfig';
 import { useRuleBuilderStore } from '../editor/ruleBuilder/useRuleBuilderStore';
 
@@ -108,6 +108,15 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
     handlePieceClick,
     handleRotate,
   } = useInteractions2D({ engine, blockedCells });
+
+  // The whole stack lifts together: selected piece + everything stacked above it.
+  const selectedStackIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!selectedPlacedPiece) return ids;
+    ids.add(selectedPlacedPiece.instanceId);
+    findPiecesStackedOnTop(board, selectedPlacedPiece).forEach(id => ids.add(id));
+    return ids;
+  }, [selectedPlacedPiece, board]);
 
   // Stable cell-level callbacks via useCallback to keep GridCell memo effective.
   // We pass x/y through closures created at render time which is fine because
@@ -226,11 +235,12 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
 
           {/* Placed pieces */}
           {board.placedPieces.map(piece => {
-            const isSelected = selectedPieceId === piece.instanceId;
+            const isClickedPiece = selectedPieceId === piece.instanceId;
+            const isInSelectedStack = selectedStackIds.has(piece.instanceId);
             const isHovered = hoveredPieceId === piece.instanceId;
             const isInteractive = !selectedInventoryPiece && !selectedPlacedPiece;
 
-            const pieceValidMoves = isSelected && config.movementRule === 'SLIDING_ONLY'
+            const pieceValidMoves = isClickedPiece && config.movementRule === 'SLIDING_ONLY'
               ? getValidSlideDestinations(board, piece)
               : [];
 
@@ -239,7 +249,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
                 key={piece.instanceId}
                 piece={piece}
                 cellSize={cellSize}
-                isSelected={isSelected}
+                isSelected={isInSelectedStack}
                 isHovered={isHovered}
                 interactive={isInteractive}
                 isSliderPuzzle={isSliderPuzzle}

--- a/src/engine/usePuzzleEngine.ts
+++ b/src/engine/usePuzzleEngine.ts
@@ -40,6 +40,9 @@ import {
   getValidSlideDestinations,
   generateInstanceId,
   getPieceCells,
+  computeRigidStackRotation,
+  computeRigidStackTranslation,
+  type StackPieceInput,
 } from './utils';
 import { createInitialBoard, createInitialInventory } from './boardFactory';
 import { enrichValidationRules, hasNoBrickRemovalRule } from './validationHelpers';
@@ -328,15 +331,10 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
     const piece = board.placedPieces.find(p => p.instanceId === instanceId);
     if (!piece) return false;
 
-    // Check if position is actually changing
     if (piece.position.x === destination.x && piece.position.y === destination.y) {
-      return true; // No change needed
+      return true;
     }
 
-    // Save snapshot for undo before mutation
-    pushSnapshot();
-
-    // For sliding puzzles, validate the move
     if (config.movementRule === 'SLIDING_ONLY') {
       const validDestinations = getValidSlideDestinations(board, piece);
       const isValidSlide = validDestinations.some(
@@ -345,88 +343,97 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
       if (!isValidSlide) return false;
     }
 
-    // Get shape and calculate new cells
-    const shape = SHAPE_LIBRARY[piece.shape];
-    if (!shape) return false;
+    // Build stack: bottom piece + everything above it (sorted by z asc).
+    const stackedIds = findPiecesStackedOnTop(board, piece);
+    const stackPieces: PlacedPiece[] = [
+      piece,
+      ...board.placedPieces
+        .filter(p => stackedIds.has(p.instanceId))
+        .sort((a, b) => a.position.z - b.position.z),
+    ];
 
-    const rotatedCells = rotateShape(shape.cells, piece.rotation);
-    const targetCells: Coordinate2D[] = rotatedCells.map(([dx, dy]) => [
-      destination.x + dx,
-      destination.y + dy,
-    ]);
+    const dx = destination.x - piece.position.x;
+    const dy = destination.y - piece.position.y;
+    const stackInputs: StackPieceInput[] = stackPieces.map(p => ({
+      position: [p.position.x, p.position.y],
+      shape: p.shape,
+      rotation: p.rotation,
+    }));
+    const transformed = computeRigidStackTranslation(stackInputs, dx, dy);
+    if (!transformed) return false;
 
-    // Validate bounds
-    if (!arePieceCellsWithinBounds(targetCells, board.dimensions)) {
-      return false;
+    for (const placement of transformed) {
+      if (!arePieceCellsWithinBounds(placement.cells, board.dimensions)) {
+        return false;
+      }
+      if (containsBlockedCells(placement.cells, board.blockedCells)) {
+        return false;
+      }
     }
 
-    // Find and remove stacked pieces
-    const stackedIds = findPiecesStackedOnTop(board, piece);
-    const stackedPieces = board.placedPieces.filter(p => stackedIds.has(p.instanceId));
+    const stackIdSet = new Set(stackPieces.map(p => p.instanceId));
+    const otherPieces = board.placedPieces.filter(p => !stackIdSet.has(p.instanceId));
+    const boardWithoutStack: EngineBoard = { ...board, placedPieces: otherPieces };
 
-    // Calculate new z-level
-    let targetZ = destination.z;
-
-    // Check for overlaps with other pieces (excluding self and stacked pieces)
-    const boardWithoutMovingPiece = {
-      ...board,
-      placedPieces: board.placedPieces.filter(
-        p => !stackedIds.has(p.instanceId) && p.instanceId !== instanceId
-      ),
-    };
-
+    let zDelta = 0;
+    let newBottomZ = piece.position.z;
     if (config.allowStacking) {
-      // With stacking allowed, calculate the appropriate z-level
-      targetZ = calculateZLevel(boardWithoutMovingPiece, targetCells, instanceId);
+      newBottomZ = calculateZLevel(boardWithoutStack, transformed[0].cells);
+      zDelta = newBottomZ - piece.position.z;
     } else {
-      // Without stacking, check if any target cells are already occupied
-      const targetCellSet = new Set(targetCells.map(([x, y]) => `${x},${y}`));
-
-      for (const otherPiece of boardWithoutMovingPiece.placedPieces) {
-        const otherCells = getPieceCells(otherPiece);
+      // No stacking allowed → bottom (and everything in stack — which should be just the
+      // bottom in this configuration) sits at z=0.
+      const targetCellSet = new Set(transformed[0].cells.map(([x, y]) => `${x},${y}`));
+      for (const other of otherPieces) {
+        const otherCells = getPieceCells(other);
         for (const [ox, oy] of otherCells) {
-          if (targetCellSet.has(`${ox},${oy}`)) {
-            // Cell already occupied and stacking not allowed - block the move
-            return false;
-          }
+          if (targetCellSet.has(`${ox},${oy}`)) return false;
         }
       }
-      targetZ = 0;
+      newBottomZ = 0;
+      zDelta = 0 - piece.position.z;
     }
 
-    // Check depth limit
+    const newZByIndex = stackPieces.map(p => p.position.z + zDelta);
     const maxAllowedZ = board.dimensions.depth - 1;
-    if (targetZ > maxAllowedZ) {
-      return false;
+    for (const z of newZByIndex) {
+      if (z < 0 || z > maxAllowedZ) return false;
     }
 
-    // Update board: remove stacked pieces and move target piece
+    const otherCellSet = new Set<string>();
+    for (const other of otherPieces) {
+      const cells = getPieceCells(other);
+      for (const [ox, oy] of cells) {
+        otherCellSet.add(`${ox},${oy},${other.position.z}`);
+      }
+    }
+    for (let i = 0; i < transformed.length; i++) {
+      const z = newZByIndex[i];
+      for (const [x, y] of transformed[i].cells) {
+        if (otherCellSet.has(`${x},${y},${z}`)) return false;
+      }
+    }
+
+    pushSnapshot();
+
     setBoard(prev => ({
       ...prev,
-      placedPieces: prev.placedPieces
-        .filter(p => !stackedIds.has(p.instanceId))
-        .map(p => p.instanceId === instanceId
-          ? { ...p, position: { ...destination, z: targetZ } }
-          : p
-        ),
+      placedPieces: prev.placedPieces.map(p => {
+        const idx = stackPieces.findIndex(sp => sp.instanceId === p.instanceId);
+        if (idx === -1) return p;
+        const t = transformed[idx];
+        return {
+          ...p,
+          position: { x: t.position[0], y: t.position[1], z: newZByIndex[idx] },
+        };
+      }),
     }));
 
-    // Return stacked pieces to inventory
-    if (stackedPieces.length > 0) {
-      setInventory(prev => {
-        const newInventory = new Map(prev);
-        for (const stackedPiece of stackedPieces) {
-          const current = newInventory.get(stackedPiece.id) ?? 0;
-          newInventory.set(stackedPiece.id, current + 1);
-        }
-        return newInventory;
-      });
-    }
-    // Increment move count for successful moves
     setMoveCount(prev => prev + 1);
     SoundManager.getInstance().play('slide');
     haptics.light();
 
+    void newBottomZ;
     return true;
   }, [board, config, pushSnapshot]);
 
@@ -435,25 +442,68 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
   // ============================================
 
   const rotatePiece = useCallback((instanceId: string) => {
-    // Check if rotation is disabled
-    if (!config.rotationEnabled) {
-      return;
+    if (!config.rotationEnabled) return;
+
+    const piece = board.placedPieces.find(p => p.instanceId === instanceId);
+    if (!piece) return;
+
+    const stackedIds = findPiecesStackedOnTop(board, piece);
+    const stackPieces: PlacedPiece[] = [
+      piece,
+      ...board.placedPieces
+        .filter(p => stackedIds.has(p.instanceId))
+        .sort((a, b) => a.position.z - b.position.z),
+    ];
+
+    const stackInputs: StackPieceInput[] = stackPieces.map(p => ({
+      position: [p.position.x, p.position.y],
+      shape: p.shape,
+      rotation: p.rotation,
+    }));
+    const transformed = computeRigidStackRotation(stackInputs);
+    if (!transformed) return;
+
+    // Note: rotation is allowed to swing cells off the board; only blocked cells
+    // and on-board collisions with non-stack pieces reject the rotation.
+    for (const placement of transformed) {
+      if (containsBlockedCells(placement.cells, board.blockedCells)) return;
+    }
+
+    const stackIdSet = new Set(stackPieces.map(p => p.instanceId));
+    const otherCellSet = new Set<string>();
+    for (const other of board.placedPieces) {
+      if (stackIdSet.has(other.instanceId)) continue;
+      const cells = getPieceCells(other);
+      for (const [ox, oy] of cells) {
+        otherCellSet.add(`${ox},${oy},${other.position.z}`);
+      }
+    }
+    for (let i = 0; i < transformed.length; i++) {
+      const z = stackPieces[i].position.z;
+      for (const [x, y] of transformed[i].cells) {
+        if (otherCellSet.has(`${x},${y},${z}`)) return;
+      }
     }
 
     pushSnapshot();
 
     setBoard(prev => ({
       ...prev,
-      placedPieces: prev.placedPieces.map(p =>
-        p.instanceId === instanceId
-          ? { ...p, rotation: (p.rotation + 90) % 360 }
-          : p
-      ),
+      placedPieces: prev.placedPieces.map(p => {
+        const idx = stackPieces.findIndex(sp => sp.instanceId === p.instanceId);
+        if (idx === -1) return p;
+        const t = transformed[idx];
+        return {
+          ...p,
+          position: { x: t.position[0], y: t.position[1], z: p.position.z },
+          rotation: t.rotation,
+        };
+      }),
     }));
 
     SoundManager.getInstance().play('rotate');
     haptics.light();
-  }, [config.rotationEnabled, pushSnapshot]);
+  }, [config.rotationEnabled, board, pushSnapshot]);
 
   // ============================================
   // SELECTION

--- a/src/engine/usePuzzleEngine.ts
+++ b/src/engine/usePuzzleEngine.ts
@@ -375,11 +375,9 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
     const otherPieces = board.placedPieces.filter(p => !stackIdSet.has(p.instanceId));
     const boardWithoutStack: EngineBoard = { ...board, placedPieces: otherPieces };
 
-    let zDelta = 0;
-    let newBottomZ = piece.position.z;
+    let zDelta: number;
     if (config.allowStacking) {
-      newBottomZ = calculateZLevel(boardWithoutStack, transformed[0].cells);
-      zDelta = newBottomZ - piece.position.z;
+      zDelta = calculateZLevel(boardWithoutStack, transformed[0].cells) - piece.position.z;
     } else {
       // No stacking allowed → bottom (and everything in stack — which should be just the
       // bottom in this configuration) sits at z=0.
@@ -390,8 +388,7 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
           if (targetCellSet.has(`${ox},${oy}`)) return false;
         }
       }
-      newBottomZ = 0;
-      zDelta = 0 - piece.position.z;
+      zDelta = -piece.position.z;
     }
 
     const newZByIndex = stackPieces.map(p => p.position.z + zDelta);
@@ -433,7 +430,6 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
     SoundManager.getInstance().play('slide');
     haptics.light();
 
-    void newBottomZ;
     return true;
   }, [board, config, pushSnapshot]);
 

--- a/src/engine/utils.ts
+++ b/src/engine/utils.ts
@@ -218,6 +218,109 @@ export function findPiecesStackedOnTop(
 }
 
 // ============================================
+// RIGID STACK TRANSFORMS
+// ============================================
+
+/**
+ * Inputs for a rigid stack transform. Operates on plain coordinates so it
+ * can be shared between the store (PlacedBrick) and engine (PlacedPiece).
+ */
+export interface StackPieceInput {
+  position: Coordinate2D;
+  shape: string;
+  rotation: number;
+}
+
+export interface StackPieceResult {
+  position: Coordinate2D;
+  rotation: number;
+  cells: Coordinate2D[];
+}
+
+/**
+ * Rotate a stack 90° around the bottom piece's pivot, matching the
+ * transform used by `rotateShape`. The bottom piece (index 0 of `pieces`)
+ * anchors the pivot — every piece in the stack rotates rigidly around it.
+ *
+ * The transform is derived from `rotateShape`'s (x, y) -> (y, -x) +
+ * normalize-to-non-negative behavior. In world coords, a cell (cx, cy)
+ * maps to (cy + (px - py), -cx + (px + py + maxX_bottom)) where
+ * (px, py) is the bottom piece's anchor and maxX_bottom is the max
+ * x-coord of the bottom piece's CURRENT (pre-rotation) shape cells.
+ * That keeps each upper piece glued to whatever cell of the bottom it
+ * was sitting on.
+ */
+export function computeRigidStackRotation(
+  pieces: StackPieceInput[],
+  shapeLibrary: Record<string, ShapeDefinition> = SHAPE_LIBRARY,
+): StackPieceResult[] | null {
+  if (pieces.length === 0) return [];
+  const bottom = pieces[0];
+  const bottomShape = shapeLibrary[bottom.shape];
+  if (!bottomShape) return null;
+
+  const bottomCurrentCells = rotateShape(bottomShape.cells, bottom.rotation);
+  const maxX = bottomCurrentCells.reduce((m, [x]) => Math.max(m, x), 0);
+  const [px, py] = bottom.position;
+
+  const out: StackPieceResult[] = [];
+  for (const piece of pieces) {
+    const shape = shapeLibrary[piece.shape];
+    if (!shape) return null;
+
+    const oldShapeCells = rotateShape(shape.cells, piece.rotation);
+    const oldWorldCells: Coordinate2D[] = oldShapeCells.map(
+      ([dx, dy]) => [piece.position[0] + dx, piece.position[1] + dy] as Coordinate2D,
+    );
+
+    const newWorldCells: Coordinate2D[] = oldWorldCells.map(
+      ([cx, cy]) => [cy + (px - py), -cx + (px + py + maxX)] as Coordinate2D,
+    );
+
+    const newRotation = ((piece.rotation % 360) + 90) % 360;
+    const newShapeCells = rotateShape(shape.cells, newRotation);
+    const minX = Math.min(...newWorldCells.map(([x]) => x));
+    const minY = Math.min(...newWorldCells.map(([, y]) => y));
+
+    // Sanity check: anchor + normalized-shape should reproduce newWorldCells.
+    // (newShapeCells is already normalized to start at (0,0), so the anchor
+    // is the (min_x, min_y) of the rigidly-rotated cells.)
+    void newShapeCells;
+
+    out.push({
+      position: [minX, minY],
+      rotation: newRotation,
+      cells: newWorldCells,
+    });
+  }
+  return out;
+}
+
+/**
+ * Translate a stack by (dx, dy). Returns new positions and world cells for
+ * each piece. Rotation is unchanged.
+ */
+export function computeRigidStackTranslation(
+  pieces: StackPieceInput[],
+  dx: number,
+  dy: number,
+  shapeLibrary: Record<string, ShapeDefinition> = SHAPE_LIBRARY,
+): StackPieceResult[] | null {
+  const out: StackPieceResult[] = [];
+  for (const piece of pieces) {
+    const shape = shapeLibrary[piece.shape];
+    if (!shape) return null;
+    const shapeCells = rotateShape(shape.cells, piece.rotation);
+    const newPosition: Coordinate2D = [piece.position[0] + dx, piece.position[1] + dy];
+    const cells: Coordinate2D[] = shapeCells.map(
+      ([sx, sy]) => [newPosition[0] + sx, newPosition[1] + sy] as Coordinate2D,
+    );
+    out.push({ position: newPosition, rotation: piece.rotation, cells });
+  }
+  return out;
+}
+
+// ============================================
 // COLLISION DETECTION
 // ============================================
 

--- a/src/store/puzzleStore.ts
+++ b/src/store/puzzleStore.ts
@@ -9,7 +9,13 @@ import {
   SHAPE_LIBRARY
 } from '../types/puzzle';
 import { ValidationRegistry, getBrickCells, rotateShape } from '../validation/ValidationRegistry';
-import { getValidSlideDestinations, generateInstanceId } from '../engine/utils';
+import {
+  getValidSlideDestinations,
+  generateInstanceId,
+  computeRigidStackRotation,
+  computeRigidStackTranslation,
+  type StackPieceInput,
+} from '../engine/utils';
 import type { EngineBoard, PlacedPiece } from '../engine/types';
 import { createInitialBoard, createInitialInventory } from '../engine/boardFactory';
 import { enrichValidationRules, hasSlidingOnlyRule, hasNoBrickRemovalRule } from '../engine/validationHelpers';
@@ -482,59 +488,99 @@ export const usePuzzleStore = create<PuzzleStore>((set, get) => ({
       }
     }
 
-    // Save snapshot for undo
+    // Build the stack (bottom + everything above), sorted by z ascending.
+    const stackedIds = findBricksStackedOnTop(boardState, brick);
+    const stackBricks: PlacedBrick[] = [
+      brick,
+      ...boardState.placedBricks
+        .filter(b => stackedIds.has(b.instanceId))
+        .sort((a, b) => (a.z || 0) - (b.z || 0)),
+    ];
+
+    const dx = newPosition.x - brick.position.x;
+    const dy = newPosition.y - brick.position.y;
+    const stackInputs: StackPieceInput[] = stackBricks.map(b => ({
+      position: [b.position.x, b.position.y],
+      shape: b.shape,
+      rotation: b.rotation,
+    }));
+    const transformed = computeRigidStackTranslation(stackInputs, dx, dy);
+    if (!transformed) {
+      setActionError(set, 'Cannot move — unknown shape');
+      return;
+    }
+
+    const { width, height, depth } = boardState.dimensions;
+    const blockedSet = new Set(boardState.blockedCells.map(([x, y]) => `${x},${y}`));
+    for (const placement of transformed) {
+      for (const [x, y] of placement.cells) {
+        if (x < 0 || x >= width || y < 0 || y >= height) {
+          setActionError(set, 'Cannot move — would go off the board');
+          return;
+        }
+        if (blockedSet.has(`${x},${y}`)) {
+          setActionError(set, 'Cannot move — cell is blocked');
+          return;
+        }
+      }
+    }
+
+    const stackIdSet = new Set(stackBricks.map(b => b.instanceId));
+    const otherBricks = boardState.placedBricks.filter(b => !stackIdSet.has(b.instanceId));
+    const tempBoardState: BoardState = { ...boardState, placedBricks: otherBricks };
+    const newBottomZ = calculateZLevel(tempBoardState, transformed[0].cells);
+    const oldBottomZ = brick.z || 0;
+    const zDelta = newBottomZ - oldBottomZ;
+    const newZByIndex = stackBricks.map(b => (b.z || 0) + zDelta);
+
+    const maxAllowedZ = depth - 1;
+    for (const z of newZByIndex) {
+      if (z < 0 || z > maxAllowedZ) {
+        setActionError(set, 'Cannot move — depth limit would be exceeded');
+        return;
+      }
+    }
+
+    const otherCellSet = new Set<string>();
+    for (const b of otherBricks) {
+      const cells = getBrickCells(b);
+      const z = b.z || 0;
+      for (const [x, y] of cells) {
+        otherCellSet.add(`${x},${y},${z}`);
+      }
+    }
+    for (let i = 0; i < transformed.length; i++) {
+      const z = newZByIndex[i];
+      for (const [x, y] of transformed[i].cells) {
+        if (otherCellSet.has(`${x},${y},${z}`)) {
+          setActionError(set, 'Cannot move — would collide with another brick');
+          return;
+        }
+      }
+    }
+
     const snapshot: BoardSnapshot = {
       boardState: { ...boardState, placedBricks: [...boardState.placedBricks] },
       inventoryState: new Map(inventoryState),
       moveCount: get().moveCount,
     };
 
-    const stackedBrickIds = findBricksStackedOnTop(boardState, brick);
-    const newInventory = new Map(inventoryState);
-    const bricksToRemove = boardState.placedBricks.filter(
-      b => stackedBrickIds.has(b.instanceId)
-    );
-    for (const brickToRemove of bricksToRemove) {
-      const current = newInventory.get(brickToRemove.id) ?? 0;
-      newInventory.set(brickToRemove.id, current + 1);
-    }
+    const updatedBricks = boardState.placedBricks.map(b => {
+      const idx = stackBricks.findIndex(sb => sb.instanceId === b.instanceId);
+      if (idx === -1) return b;
+      const t = transformed[idx];
+      return {
+        ...b,
+        position: { x: t.position[0], y: t.position[1] },
+        z: newZByIndex[idx],
+      };
+    });
 
-    const bricksWithoutStacked = boardState.placedBricks.filter(
-      b => !stackedBrickIds.has(b.instanceId)
-    );
-
-    const shape = SHAPE_LIBRARY[brick.shape];
-    if (!shape) return;
-
-    const rotatedCells = rotateShape(shape.cells, brick.rotation || 0);
-    const cells: [number, number][] = rotatedCells.map(([dx, dy]) => [
-      newPosition.x + dx,
-      newPosition.y + dy,
-    ]);
-
-    const otherBricks = bricksWithoutStacked.filter(b => b.instanceId !== instanceId);
-    const tempBoardState: BoardState = { ...boardState, placedBricks: otherBricks };
-    const zLevel = calculateZLevel(tempBoardState, cells);
-
-    const maxAllowedZ = boardState.dimensions.depth - 1;
-    if (zLevel > maxAllowedZ) {
-      setActionError(set, 'Cannot move — depth limit would be exceeded');
-      return;
-    }
-
-    const newBoardState = {
-      ...boardState,
-      placedBricks: bricksWithoutStacked.map(b =>
-        b.instanceId === instanceId
-          ? { ...b, position: newPosition, z: zLevel }
-          : b
-      ),
-    };
+    const newBoardState = { ...boardState, placedBricks: updatedBricks };
     const newMoveCount = get().moveCount + 1;
 
     set({
       boardState: newBoardState,
-      inventoryState: newInventory,
       moveCount: newMoveCount,
       undoStack: [...undoStack.slice(-(MAX_UNDO_HISTORY - 1)), snapshot],
       redoStack: [],
@@ -547,20 +593,78 @@ export const usePuzzleStore = create<PuzzleStore>((set, get) => ({
   rotateBrick: (instanceId) => {
     const { boardState, undoStack, inventoryState } = get();
 
+    const brick = boardState.placedBricks.find(b => b.instanceId === instanceId);
+    if (!brick) return;
+
+    const stackedIds = findBricksStackedOnTop(boardState, brick);
+    const stackBricks: PlacedBrick[] = [
+      brick,
+      ...boardState.placedBricks
+        .filter(b => stackedIds.has(b.instanceId))
+        .sort((a, b) => (a.z || 0) - (b.z || 0)),
+    ];
+
+    const stackInputs: StackPieceInput[] = stackBricks.map(b => ({
+      position: [b.position.x, b.position.y],
+      shape: b.shape,
+      rotation: b.rotation,
+    }));
+    const transformed = computeRigidStackRotation(stackInputs);
+    if (!transformed) {
+      setActionError(set, 'Cannot rotate — unknown shape');
+      return;
+    }
+
+    // Note: rotation is allowed to swing cells off the board; only on-board
+    // blocked cells and on-board collisions with non-stack bricks reject the move.
+    const blockedSet = new Set(boardState.blockedCells.map(([x, y]) => `${x},${y}`));
+    for (const placement of transformed) {
+      for (const [x, y] of placement.cells) {
+        if (blockedSet.has(`${x},${y}`)) {
+          setActionError(set, 'Cannot rotate — cell is blocked');
+          return;
+        }
+      }
+    }
+
+    const stackIdSet = new Set(stackBricks.map(b => b.instanceId));
+    const otherCellSet = new Set<string>();
+    for (const b of boardState.placedBricks) {
+      if (stackIdSet.has(b.instanceId)) continue;
+      const cells = getBrickCells(b);
+      const z = b.z || 0;
+      for (const [x, y] of cells) {
+        otherCellSet.add(`${x},${y},${z}`);
+      }
+    }
+    for (let i = 0; i < transformed.length; i++) {
+      const z = stackBricks[i].z || 0;
+      for (const [x, y] of transformed[i].cells) {
+        if (otherCellSet.has(`${x},${y},${z}`)) {
+          setActionError(set, 'Cannot rotate — would collide with another brick');
+          return;
+        }
+      }
+    }
+
     const snapshot: BoardSnapshot = {
       boardState: { ...boardState, placedBricks: [...boardState.placedBricks] },
       inventoryState: new Map(inventoryState),
       moveCount: get().moveCount,
     };
 
-    const newBoardState = {
-      ...boardState,
-      placedBricks: boardState.placedBricks.map(b =>
-        b.instanceId === instanceId
-          ? { ...b, rotation: (b.rotation + 90) % 360 }
-          : b
-      ),
-    };
+    const updatedBricks = boardState.placedBricks.map(b => {
+      const idx = stackBricks.findIndex(sb => sb.instanceId === b.instanceId);
+      if (idx === -1) return b;
+      const t = transformed[idx];
+      return {
+        ...b,
+        position: { x: t.position[0], y: t.position[1] },
+        rotation: t.rotation,
+      };
+    });
+
+    const newBoardState = { ...boardState, placedBricks: updatedBricks };
 
     set({
       boardState: newBoardState,


### PR DESCRIPTION
Selecting a brick that has bricks stacked on top now treats the whole stack as a single body for both move and rotate (3D scene + 2D engine). Previously the upper bricks were dropped back to inventory on move and left untouched on rotate, which made tall builds painful to reposition. Selecting any brick lifts the brick plus everything above it so the user sees what will move. Rotation is permitted to swing cells off the board; moves still validate bounds, blocked cells, depth, and collisions with non-stack bricks, rejecting the whole transform on conflict.