### PR TITLE
Add link, HTML, and image attachments to puzzle description

### DIFF
--- a/src/components/editor/PuzzleEditor.tsx
+++ b/src/components/editor/PuzzleEditor.tsx
@@ -252,6 +252,43 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
     return () => { if (debounceRef.current) window.clearTimeout(debounceRef.current); };
   }, []);
 
+  // ---- Upload HTML or JPEG description ----
+  const uploadInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUploadChosen = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // allow re-selecting the same file
+    if (!file) return;
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(jsonSource);
+    } catch {
+      // Invalid JSON in editor — refuse to splice into broken JSON.
+      return;
+    }
+
+    const isHtml = /\.html?$/i.test(file.name) || file.type === 'text/html';
+    const isJpeg = /\.jpe?g$/i.test(file.name) || file.type === 'image/jpeg';
+
+    if (isHtml) {
+      parsed.description_html = await file.text();
+    } else if (isJpeg) {
+      const buf = await file.arrayBuffer();
+      const bytes = new Uint8Array(buf);
+      let bin = '';
+      for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+      parsed.description_image = `data:image/jpeg;base64,${btoa(bin)}`;
+    } else {
+      return; // unsupported
+    }
+
+    const next = JSON.stringify(parsed, null, 2);
+    setJsonSource(next);
+    setIsModified(true);
+    validateAndUpdate(next);
+  }, [jsonSource, setJsonSource, validateAndUpdate]);
+
   const hasErrors = localErrors.length > 0 || parseError;
 
   return (
@@ -273,15 +310,33 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
             </Badge>
           )}
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 text-xs gap-1.5"
-          onClick={() => editorRef.current?.getAction('editor.action.formatDocument')?.run()}
-        >
-          Format
-          <kbd className="hidden md:inline text-[10px] font-mono text-muted-foreground bg-secondary px-1 rounded">Shift+Alt+F</kbd>
-        </Button>
+        <div className="flex items-center gap-1.5">
+          <input
+            ref={uploadInputRef}
+            type="file"
+            accept=".html,.htm,text/html,.jpg,.jpeg,image/jpeg"
+            className="hidden"
+            onChange={handleUploadChosen}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1.5"
+            onClick={() => uploadInputRef.current?.click()}
+            title="Attach an HTML file (sandboxed) or JPEG image to the description"
+          >
+            Upload
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs gap-1.5"
+            onClick={() => editorRef.current?.getAction('editor.action.formatDocument')?.run()}
+          >
+            Format
+            <kbd className="hidden md:inline text-[10px] font-mono text-muted-foreground bg-secondary px-1 rounded">Shift+Alt+F</kbd>
+          </Button>
+        </div>
       </div>
 
       {/* Monaco Editor */}

--- a/src/components/ui/PuzzleInfoPanel.tsx
+++ b/src/components/ui/PuzzleInfoPanel.tsx
@@ -47,6 +47,31 @@ export function PuzzleInfoPanel({ className = '', engine }: PuzzleInfoPanelProps
           <p className="text-xs text-muted-foreground whitespace-pre-wrap leading-relaxed">
             {puzzle.description}
           </p>
+          {puzzle.link && (
+            <a
+              href={puzzle.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-block text-xs text-primary hover:underline break-all"
+            >
+              {puzzle.link_label ?? puzzle.link}
+            </a>
+          )}
+          {puzzle.description_image && (
+            <img
+              src={puzzle.description_image}
+              alt="Puzzle illustration"
+              className="mt-3 w-full max-h-56 object-contain rounded-lg border border-border bg-background"
+            />
+          )}
+          {puzzle.description_html && (
+            <iframe
+              title="Puzzle description"
+              srcDoc={puzzle.description_html}
+              sandbox=""
+              className="mt-3 w-full h-56 rounded-lg border border-border bg-background"
+            />
+          )}
         </section>
 
         <section className="rounded-xl border border-border bg-[var(--surface-raised)] p-3">

--- a/src/components/ui/PuzzleInfoPopup.tsx
+++ b/src/components/ui/PuzzleInfoPopup.tsx
@@ -139,6 +139,31 @@ export function PuzzleInfoPopup({ isOpen, onClose, engine }: PuzzleInfoPopupProp
                   {puzzle.description}
                 </p>
               )}
+              {puzzle.link && (
+                <a
+                  href={puzzle.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-block text-sm text-primary hover:underline break-all"
+                >
+                  {puzzle.link_label ?? puzzle.link}
+                </a>
+              )}
+              {puzzle.description_image && (
+                <img
+                  src={puzzle.description_image}
+                  alt="Puzzle illustration"
+                  className="mt-3 w-full max-h-64 object-contain rounded-lg border border-border bg-background"
+                />
+              )}
+              {puzzle.description_html && (
+                <iframe
+                  title="Puzzle description"
+                  srcDoc={puzzle.description_html}
+                  sandbox=""
+                  className="mt-3 w-full h-64 rounded-lg border border-border bg-background"
+                />
+              )}
               <div className="flex items-center gap-2 mt-3">
                 <Badge variant="secondary" className="text-[10px] font-mono">{board.width}&times;{board.height} board</Badge>
                 <Badge variant="outline" className="text-[10px]">{puzzle.viewMode} mode</Badge>

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -222,6 +222,19 @@ export const PuzzleDefinitionSchema = z.object({
   puzzle_id: z.string().optional(),
   title: z.string(),
   description: z.string(),
+  /** Optional external link rendered alongside the description (e.g. source
+   * page, reference, video). `link_label` is the text shown for the link;
+   * if omitted, the URL itself is shown. */
+  link: z.string().url().optional(),
+  link_label: z.string().optional(),
+  /** Optional rich HTML description rendered inside a sandboxed iframe
+   * (no scripts, no same-origin) below the plain description. Useful for
+   * authored explainers, diagrams, or styled instructions. Populated via
+   * the "Upload" button in the puzzle editor. */
+  description_html: z.string().optional(),
+  /** Optional image (data URL, e.g. JPEG) rendered below the description.
+   * Populated via the "Upload" button in the puzzle editor. */
+  description_image: z.string().optional(),
   /** View mode determines how the puzzle is rendered (3D or 2D) */
   viewMode: ViewModeSchema.default('3D'),
   board: BoardSchema,


### PR DESCRIPTION
## Summary

Three new optional fields on `PuzzleDefinition` let authors enrich the description shown in the puzzle info panel and popup:

- **`link` / `link_label`** — external URL rendered as a clickable link below the description text. Label falls back to the URL itself if omitted.
- **`description_html`** — HTML content embedded inline in a sandboxed `<iframe srcDoc sandbox="">` (no scripts, no same-origin) so even hostile markup can't escape into the parent app.
- **`description_image`** — image data URL (JPEG) rendered as a styled `<img>` tag.

The puzzle editor's toolbar gains an **Upload** button that accepts `.html`/`.htm` or `.jpg`/`.jpeg`. It reads the file in-browser and splices the result into the JSON under the appropriate field — HTML as text into `description_html`, JPEG as a base64 data URL into `description_image`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` (686/686 passing — schema additions are optional, no existing tests touched)
- [x] Manual: upload an HTML file in the editor, confirm it shows in the sandboxed iframe in the info panel/popup
- [x] Manual: upload a JPEG, confirm it renders as an image
- [x] Manual: set `link` + `link_label` in the JSON, confirm it renders as a clickable link with the chosen label