### PR TITLE
Highlight failing cells + per-cell board paint

### DIFF
--- a/src/components/3d/LegoBoard.tsx
+++ b/src/components/3d/LegoBoard.tsx
@@ -240,12 +240,22 @@ export function LegoBoard({
     return new Set(pickerSelectedCells.map(([x, y]) => `${x},${y}`));
   }, [pickerSelectedCells]);
 
-  // Get cells that need highlighting from validation
+  // Per-cell paint colors from puzzle.board.cell_colors.
+  const cellColorMap = useMemo(() => {
+    const m = new Map<string, string>();
+    const entries = store.puzzle?.board.cell_colors ?? [];
+    for (const [x, y, color] of entries) m.set(`${x},${y}`, color);
+    return m;
+  }, [store.puzzle?.board.cell_colors]);
+
+  // Get cells that need highlighting from validation. Opt-in via
+  // puzzle.highlight_failing_cells — when on, every failing rule's
+  // affectedCells are painted red (including CUSTOM rules).
+  const highlightFailingCells = store.puzzle?.highlight_failing_cells ?? false;
   const invalidCells = useMemo(() => {
     const cells = new Set<string>();
+    if (!highlightFailingCells) return cells;
     for (const result of validationResults) {
-      // Custom rules manage their own display — don't paint affected cells red
-      if (result.rule.startsWith('CUSTOM:')) continue;
       if (!result.isValid && result.affectedCells) {
         for (const [x, y] of result.affectedCells) {
           cells.add(`${x},${y}`);
@@ -253,7 +263,7 @@ export function LegoBoard({
       }
     }
     return cells;
-  }, [validationResults]);
+  }, [validationResults, highlightFailingCells]);
 
   // Create blocked cells set
   const blockedCells = useMemo(() => {
@@ -284,6 +294,7 @@ export function LegoBoard({
     const baseNormal: CellPosition[] = [];
     const baseBlocked: CellPosition[] = [];
     const baseGoal: CellPosition[] = [];
+    const baseColored: HighlightInstance[] = [];
     const studNormal: CellPosition[] = [];
     const studGoal: CellPosition[] = [];
     const highlights: HighlightInstance[] = [];
@@ -298,6 +309,7 @@ export function LegoBoard({
         const isInvalid = invalidCells.has(key);
         const isSlideDestination = slideDestinationCells.has(key);
         const isGoal = goalCellSet.has(key);
+        const paintColor = cellColorMap.get(key);
         const highlightColor = isInvalid
           ? COLORS.invalidCell
           : isSlideDestination
@@ -308,6 +320,8 @@ export function LegoBoard({
 
         if (isBlocked) {
           baseBlocked.push([x, y]);
+        } else if (paintColor) {
+          baseColored.push({ x, y, color: paintColor });
         } else if (isGoal) {
           baseGoal.push([x, y]);
         } else {
@@ -338,13 +352,14 @@ export function LegoBoard({
       baseNormal,
       baseBlocked,
       baseGoal,
+      baseColored,
       studNormal,
       studGoal,
       highlights,
       goalRings,
       pickerHighlights,
     };
-  }, [width, height, blockedCells, hoveredCell, invalidCells, slideDestinationCells, goalCellSet, pickerCellSet]);
+  }, [width, height, blockedCells, hoveredCell, invalidCells, slideDestinationCells, goalCellSet, cellColorMap, pickerCellSet]);
 
   useLayoutEffect(() => {
     const dynamicMeshes = [
@@ -495,6 +510,26 @@ export function LegoBoard({
           clearcoatRoughness={0.6}
         />
       </instancedMesh>
+
+      {/* Painted cells from puzzle.board.cell_colors. One mesh per cell so
+          each gets its own material color; positioned slightly above the
+          regular cell tops so the rim doesn't obscure them. */}
+      {instanceData.baseColored.map(({ x, y, color }) => (
+        <mesh
+          key={`painted-${x}-${y}`}
+          position={[x + 0.5, -BOARD_DEPTH / 2 + 0.06, y + 0.5]}
+          receiveShadow
+        >
+          <boxGeometry args={[CELL_SIZE - 0.02, BOARD_DEPTH, CELL_SIZE - 0.02]} />
+          <meshPhysicalMaterial
+            color={color}
+            roughness={BOARD_3D.roughness}
+            metalness={BOARD_3D.metalness}
+            clearcoat={0.45}
+            clearcoatRoughness={0.6}
+          />
+        </mesh>
+      ))}
 
       {/* Instanced studs */}
       <instancedMesh ref={studNormalRef} args={[undefined, undefined, maxInstances]} castShadow>

--- a/src/components/3d/PolyominoBrick.tsx
+++ b/src/components/3d/PolyominoBrick.tsx
@@ -11,6 +11,9 @@ interface PolyominoBrickProps {
   isSelected?: boolean;
   isGhost?: boolean;
   isValid?: boolean;
+  /** When true, the brick glows red — used to flag bricks that overlap a
+   * failing validation rule's affectedCells. */
+  isInvalid?: boolean;
   interactive?: boolean; // Whether the brick responds to clicks
   onSelect?: () => void;
   onDeselect?: () => void;
@@ -35,6 +38,7 @@ function BrickCell({
   isGhost,
   isSelected,
   isHovering,
+  isInvalid,
 }: {
   x: number;
   y: number;
@@ -42,6 +46,7 @@ function BrickCell({
   isGhost?: boolean;
   isSelected?: boolean;
   isHovering?: boolean;
+  isInvalid?: boolean;
 }) {
   const baseColor = useMemo(() => new THREE.Color(color), [color]);
   const edgeTint = useMemo(() => baseColor.clone().offsetHSL(0, 0.01, -0.08).getStyle(), [baseColor]);
@@ -66,8 +71,8 @@ function BrickCell({
           clearcoatRoughness={BRICK_3D.clearcoatRoughness}
           transparent={isGhost}
           opacity={isGhost ? 0.56 : 1}
-          emissive={isSelected || isHovering ? color : '#000000'}
-          emissiveIntensity={isSelected || isHovering ? BRICK_3D.emissiveIntensity : 0}
+          emissive={isInvalid ? '#ff2a2a' : (isSelected || isHovering ? color : '#000000')}
+          emissiveIntensity={isInvalid ? 0.55 : (isSelected || isHovering ? BRICK_3D.emissiveIntensity : 0)}
         />
       </RoundedBox>
 
@@ -117,6 +122,7 @@ export function PolyominoBrick({
   isSelected = false,
   isGhost = false,
   isValid = true,
+  isInvalid = false,
   interactive = true, // Default to interactive
   onSelect,
   onDeselect,
@@ -261,9 +267,10 @@ export function PolyominoBrick({
         isGhost={isGhost}
         isSelected={isSelected}
         isHovering={hovered && interactive}
+        isInvalid={isInvalid}
       />
     ));
-  }, [rotatedCells, brick.color, isGhost, isSelected, isValid, hovered, interactive]);
+  }, [rotatedCells, brick.color, isGhost, isSelected, isValid, isInvalid, hovered, interactive]);
 
   if (!shape) {
     console.warn(`Unknown shape: ${brick.shape}`);

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -342,6 +342,28 @@ function DragDropManager() {
     return ids;
   }, [selectedPlacedBrick, boardState.placedBricks]);
 
+  // Bricks whose cells overlap any failing rule's affectedCells, when
+  // puzzle.highlight_failing_cells is on. Tints the offending bricks red so
+  // the failure is visible even though the floor highlight is hidden by them.
+  const validationResults = usePuzzleStore(s => s.validationResults);
+  const invalidBrickIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!puzzle?.highlight_failing_cells) return ids;
+    const invalidCellSet = new Set<string>();
+    for (const r of validationResults) {
+      if (r.isValid || !r.affectedCells) continue;
+      for (const [x, y] of r.affectedCells) invalidCellSet.add(`${x},${y}`);
+    }
+    if (invalidCellSet.size === 0) return ids;
+    for (const b of boardState.placedBricks) {
+      const cells = getBrickCells(b);
+      if (cells.some(([x, y]) => invalidCellSet.has(`${x},${y}`))) {
+        ids.add(b.instanceId);
+      }
+    }
+    return ids;
+  }, [puzzle?.highlight_failing_cells, validationResults, boardState.placedBricks]);
+
   // Calculate z-level for ghost preview (for stacking)
   const ghostZLevel = useMemo(() => {
     if (!selectedInventoryBrick || !hoveredCell) return 0;
@@ -568,12 +590,14 @@ function DragDropManager() {
         // become non-interactive so clicks pass through to the board for movement
         const isThisBrickInSelectedStack = selectedStackIds.has(brick.instanceId);
         const isInteractive = !selectedInventoryBrick && !selectedPlacedBrick;
+        const isThisBrickInvalid = invalidBrickIds.has(brick.instanceId);
 
         return (
           <PolyominoBrick
             key={brick.instanceId}
             brick={brick}
             isSelected={isThisBrickInSelectedStack}
+            isInvalid={isThisBrickInvalid}
             interactive={isInteractive}
             boardOffset={boardOffset}
             onSelect={() => handleBrickSelect(brick.instanceId)}

--- a/src/components/renderer/2d/GridCell2D.tsx
+++ b/src/components/renderer/2d/GridCell2D.tsx
@@ -14,6 +14,8 @@ export interface GridCellProps {
   isInvalid: boolean;
   isValidDestination: boolean;
   isPickerSelected?: boolean;
+  /** Override fill color for this board cell (from `board.cell_colors`). */
+  paintColor?: string;
   onClick: () => void;
   onPointerEnter: () => void;
   onPointerLeave: () => void;
@@ -28,6 +30,7 @@ export const GridCell = memo(function GridCell({
   isInvalid,
   isValidDestination,
   isPickerSelected,
+  paintColor,
   onClick,
   onPointerEnter,
   onPointerLeave,
@@ -48,7 +51,7 @@ export const GridCell = memo(function GridCell({
           ? C.validDest
           : isBlocked
             ? 'url(#cell-blocked-grad)'
-            : 'url(#cell-grad)';
+            : paintColor ?? 'url(#cell-grad)';
 
   return (
     <g

--- a/src/components/renderer/2d/Piece2D.tsx
+++ b/src/components/renderer/2d/Piece2D.tsx
@@ -29,6 +29,9 @@ export interface PieceProps {
   interactive: boolean;
   isSliderPuzzle: boolean;
   hasValidMoves: boolean;
+  /** When true, the piece's outline is drawn in red — used to flag pieces
+   * that overlap a failing validation rule's affectedCells. */
+  isInvalid?: boolean;
   onClick: () => void;
   onPointerEnter: () => void;
   onPointerLeave: () => void;
@@ -42,6 +45,7 @@ export const Piece2D = memo(function Piece2D({
   interactive,
   isSliderPuzzle,
   hasValidMoves,
+  isInvalid = false,
   onClick,
   onPointerEnter,
   onPointerLeave,
@@ -185,8 +189,8 @@ export const Piece2D = memo(function Piece2D({
             y1={edge.y1}
             x2={edge.x2}
             y2={edge.y2}
-            stroke={isSelected ? C.selectionGlow : borderColor}
-            strokeWidth={isSelected ? 3.5 : isHovered ? 3 : 2.5}
+            stroke={isInvalid ? '#ff2a2a' : (isSelected ? C.selectionGlow : borderColor)}
+            strokeWidth={isInvalid ? 4 : (isSelected ? 3.5 : isHovered ? 3 : 2.5)}
             strokeLinecap="square"
             opacity={isSelected ? 0.9 : 1}
           />

--- a/src/components/renderer/2d/useInteractions2D.ts
+++ b/src/components/renderer/2d/useInteractions2D.ts
@@ -243,15 +243,13 @@ export function useInteractions2D({ engine, blockedCells }: UseInteractions2DOpt
 
   // ---- invalid cells ----
 
+  // Opt-in via puzzle.highlight_failing_cells — when on, every failing
+  // rule's affectedCells are painted red (including CUSTOM rules).
+  const highlightFailingCells = puzzle?.highlight_failing_cells ?? false;
   const invalidCells = useMemo(() => {
     const cells = new Set<string>();
+    if (!highlightFailingCells) return cells;
     for (const result of engine.validationResults) {
-      if (result.rule === 'GOAL_REACHED') continue;
-      if (result.rule === 'ALL_BOARD_SQUARES_MUST_BE_COVERED') continue;
-      if (result.rule === 'PATTERN_MATCH') continue;
-      // Custom rules manage their own display — don't paint affected cells red
-      if (result.rule.startsWith('CUSTOM:')) continue;
-
       if (!result.isValid && result.affectedCells) {
         for (const [x, y] of result.affectedCells) {
           cells.add(`${x},${y}`);
@@ -259,7 +257,7 @@ export function useInteractions2D({ engine, blockedCells }: UseInteractions2DOpt
       }
     }
     return cells;
-  }, [engine.validationResults]);
+  }, [engine.validationResults, highlightFailingCells]);
 
   // ---- goal area ----
 

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -9,7 +9,7 @@
 
 import { useMemo, useCallback, useEffect, useState, useRef } from 'react';
 import type { UsePuzzleEngineReturn } from '../../engine';
-import { getValidSlideDestinations, findPiecesStackedOnTop } from '../../engine';
+import { getValidSlideDestinations, findPiecesStackedOnTop, getPieceCells } from '../../engine';
 import { SCENE_2D } from '../../config/sceneConfig';
 import { useRuleBuilderStore } from '../editor/ruleBuilder/useRuleBuilderStore';
 
@@ -94,6 +94,14 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
     [board.blockedCells],
   );
 
+  // Per-cell paint colors from puzzle.board.cell_colors.
+  const cellColorMap = useMemo(() => {
+    const m = new Map<string, string>();
+    const entries = puzzle?.board.cell_colors ?? [];
+    for (const [x, y, color] of entries) m.set(`${x},${y}`, color);
+    return m;
+  }, [puzzle?.board.cell_colors]);
+
   // All interaction state and handlers
   const {
     hoveredPieceId,
@@ -117,6 +125,27 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
     findPiecesStackedOnTop(board, selectedPlacedPiece).forEach(id => ids.add(id));
     return ids;
   }, [selectedPlacedPiece, board]);
+
+  // Pieces whose cells overlap any failing rule's affectedCells, when
+  // puzzle.highlight_failing_cells is on. Drawn with a red outline so the
+  // failure is visible even when a piece covers the affected cell.
+  const invalidPieceIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!puzzle?.highlight_failing_cells) return ids;
+    const invalidCellSet = new Set<string>();
+    for (const r of engine.validationResults) {
+      if (r.isValid || !r.affectedCells) continue;
+      for (const [x, y] of r.affectedCells) invalidCellSet.add(`${x},${y}`);
+    }
+    if (invalidCellSet.size === 0) return ids;
+    for (const p of board.placedPieces) {
+      const cells = getPieceCells(p);
+      if (cells.some(([x, y]) => invalidCellSet.has(`${x},${y}`))) {
+        ids.add(p.instanceId);
+      }
+    }
+    return ids;
+  }, [puzzle?.highlight_failing_cells, engine.validationResults, board.placedPieces]);
 
   // Stable cell-level callbacks via useCallback to keep GridCell memo effective.
   // We pass x/y through closures created at render time which is fine because
@@ -225,6 +254,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
                   isInvalid={isInvalid}
                   isValidDestination={isValidDest}
                   isPickerSelected={isPickerSel}
+                  paintColor={cellColorMap.get(key)}
                   onClick={() => handleCellClick(x, y)}
                   onPointerEnter={() => onCellPointerEnter(x, y)}
                   onPointerLeave={onCellPointerLeave}
@@ -239,6 +269,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
             const isInSelectedStack = selectedStackIds.has(piece.instanceId);
             const isHovered = hoveredPieceId === piece.instanceId;
             const isInteractive = !selectedInventoryPiece && !selectedPlacedPiece;
+            const isPieceInvalid = invalidPieceIds.has(piece.instanceId);
 
             const pieceValidMoves = isClickedPiece && config.movementRule === 'SLIDING_ONLY'
               ? getValidSlideDestinations(board, piece)
@@ -250,6 +281,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
                 piece={piece}
                 cellSize={cellSize}
                 isSelected={isInSelectedStack}
+                isInvalid={isPieceInvalid}
                 isHovered={isHovered}
                 interactive={isInteractive}
                 isSliderPuzzle={isSliderPuzzle}

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -133,6 +133,11 @@ export const BoardSchema = z.object({
   initial_state: z.array(InitialPlacementSchema).default([]),
   /** Optional blocked cells that cannot be used */
   blocked_cells: z.array(z.tuple([z.number(), z.number()])).optional(),
+  /** Optional per-cell board paint. Each entry is `[x, y, color]`. The board
+   * cell at (x, y) is painted in the given color (CSS color string) instead
+   * of the default surface color. Useful for marking lanes, peg sections,
+   * or color-coded zones. */
+  cell_colors: z.array(z.tuple([z.number(), z.number(), z.string()])).optional(),
 });
 
 export type Board = z.infer<typeof BoardSchema>;
@@ -235,6 +240,11 @@ export const PuzzleDefinitionSchema = z.object({
   /** Optional image (data URL, e.g. JPEG) rendered below the description.
    * Populated via the "Upload" button in the puzzle editor. */
   description_image: z.string().optional(),
+  /** When true, cells reported as `affectedCells` by failing validation
+   * rules are highlighted on the board (red overlay). Defaults to false
+   * — authors opt in for puzzles where the failure reason should be
+   * visible to the player. */
+  highlight_failing_cells: z.boolean().optional(),
   /** View mode determines how the puzzle is rendered (3D or 2D) */
   viewMode: ViewModeSchema.default('3D'),
   board: BoardSchema,


### PR DESCRIPTION
## Summary

Two new opt-in fields on `PuzzleDefinition` for surfacing rule failures and authoring colored board layouts.

### `highlight_failing_cells` (default `false`)
When true, every failing rule's `affectedCells` get marked on the board:
- **3D**: red emissive glow on any brick whose footprint overlaps an affected cell. Floor highlight remains for empty cells.
- **2D**: red outline (stroke `#ff2a2a`, width 4) around any piece overlapping an affected cell, plus the existing red cell fill for empty cells.

The brick-tint half is what makes failures visible when a piece covers the affected cell — otherwise the floor highlight just sits underneath the brick.

### `board.cell_colors`
New optional field on the board:

```json
"board": {
  "dimensions": { ... },
  "cell_colors": [
    [0, 0, "#ffaa00"],
    [8, 2, "#00aaff"]
  ]
}
```

Each entry paints one cell with the given CSS color string. Useful for marking lanes, peg sections, or color-coded zones.
- **3D**: rendered as a per-cell `meshPhysicalMaterial` slightly raised above the rim so it isn't occluded.
- **2D**: rendered as the cell's fill color (with priority below special states like hover/invalid/picker).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` (686/686 passing — schema additions are optional, no existing tests touched)
- [x] Manual: set `highlight_failing_cells: true`, place pieces violating a rule, confirm both the bricks and any empty affected cells turn red in 3D and 2D
- [x] Manual: set `board.cell_colors`, confirm cells render in the chosen colors in both views