### PR TITLE
Generic moves engine: permute transform + button trigger + lock_pieces

### DIFF
--- a/src/app/PuzzleShell.tsx
+++ b/src/app/PuzzleShell.tsx
@@ -5,6 +5,7 @@ import { ResizablePanels } from '../components/layout/ResizablePanels';
 import { PuzzleRenderer, ViewModeIndicator } from '../components/renderer';
 import { InventoryPanel } from '../components/ui/InventoryPanel';
 import { ValidationPanel } from '../components/ui/ValidationPanel';
+import { MovesPanel } from '../components/ui/MovesPanel';
 import { PuzzleInfoPopup } from '../components/ui/PuzzleInfoPopup';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/shadcn/tabs';
 import { Button } from '../components/ui/shadcn/button';
@@ -117,27 +118,44 @@ function SidePanel({ puzzle, showInfo, setShowInfo, activeEngine, validationResu
           {flipped ? <PanelRightOpen className="w-3.5 h-3.5" /> : <PanelLeftOpen className="w-3.5 h-3.5" />}
         </Button>
       </div>
-      <Tabs defaultValue="inventory" className="flex-1 min-h-0 flex flex-col gap-0 px-2 pb-2">
-        <div className="shrink-0 pb-1.5">
-          <TabsList variant="line" className="w-full h-9 grid grid-cols-2 rounded-lg bg-[var(--surface-raised)] border border-border">
-            <TabsTrigger value="inventory" className="text-xs">Inventory</TabsTrigger>
-            <TabsTrigger value="validation" className="text-xs gap-1.5">
-              Validation
-              {validationResults.length > 0 && (
-                <span className={`text-[9px] font-mono px-1 py-0 rounded ${isComplete ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'}`}>
-                  {validationResults.filter(r => r.isValid).length}/{validationResults.length}
-                </span>
-              )}
-            </TabsTrigger>
-          </TabsList>
-        </div>
-        <TabsContent value="inventory" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
-          <InventoryPanel className="h-full" engine={activeEngine} />
-        </TabsContent>
-        <TabsContent value="validation" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
-          <ValidationPanel className="h-full" engine={activeEngine} />
-        </TabsContent>
-      </Tabs>
+      {(() => {
+        const hasMoves = (puzzle?.moves?.length ?? 0) > 0;
+        const defaultTab = hasMoves ? 'moves' : 'inventory';
+        return (
+          <Tabs defaultValue={defaultTab} className="flex-1 min-h-0 flex flex-col gap-0 px-2 pb-2">
+            <div className="shrink-0 pb-1.5">
+              <TabsList
+                variant="line"
+                className={`w-full h-9 grid ${hasMoves ? 'grid-cols-3' : 'grid-cols-2'} rounded-lg bg-[var(--surface-raised)] border border-border`}
+              >
+                {hasMoves && (
+                  <TabsTrigger value="moves" className="text-xs">Moves</TabsTrigger>
+                )}
+                <TabsTrigger value="inventory" className="text-xs">Inventory</TabsTrigger>
+                <TabsTrigger value="validation" className="text-xs gap-1.5">
+                  Validation
+                  {validationResults.length > 0 && (
+                    <span className={`text-[9px] font-mono px-1 py-0 rounded ${isComplete ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'}`}>
+                      {validationResults.filter(r => r.isValid).length}/{validationResults.length}
+                    </span>
+                  )}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            {hasMoves && (
+              <TabsContent value="moves" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+                <MovesPanel className="h-full" engine={activeEngine} />
+              </TabsContent>
+            )}
+            <TabsContent value="inventory" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+              <InventoryPanel className="h-full" engine={activeEngine} />
+            </TabsContent>
+            <TabsContent value="validation" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+              <ValidationPanel className="h-full" engine={activeEngine} />
+            </TabsContent>
+          </Tabs>
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -589,7 +589,10 @@ function DragDropManager() {
         // When a placed brick is selected for moving, ALL bricks (including the selected one) 
         // become non-interactive so clicks pass through to the board for movement
         const isThisBrickInSelectedStack = selectedStackIds.has(brick.instanceId);
-        const isInteractive = !selectedInventoryBrick && !selectedPlacedBrick;
+        // lock_pieces disables direct user interaction with pieces — the
+        // board can only be changed via puzzle.moves[] in that mode.
+        const piecesLocked = puzzle?.lock_pieces ?? false;
+        const isInteractive = !piecesLocked && !selectedInventoryBrick && !selectedPlacedBrick;
         const isThisBrickInvalid = invalidBrickIds.has(brick.instanceId);
 
         return (

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -268,7 +268,10 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
             const isClickedPiece = selectedPieceId === piece.instanceId;
             const isInSelectedStack = selectedStackIds.has(piece.instanceId);
             const isHovered = hoveredPieceId === piece.instanceId;
-            const isInteractive = !selectedInventoryPiece && !selectedPlacedPiece;
+            // lock_pieces disables direct user interaction with pieces — the
+            // board can only be changed via puzzle.moves[] in that mode.
+            const piecesLocked = puzzle?.lock_pieces ?? false;
+            const isInteractive = !piecesLocked && !selectedInventoryPiece && !selectedPlacedPiece;
             const isPieceInvalid = invalidPieceIds.has(piece.instanceId);
 
             const pieceValidMoves = isClickedPiece && config.movementRule === 'SLIDING_ONLY'

--- a/src/components/ui/MovesPanel.tsx
+++ b/src/components/ui/MovesPanel.tsx
@@ -1,0 +1,73 @@
+import { usePuzzleStore } from '../../store/puzzleStore';
+import { Button } from '../ui/shadcn/button';
+import { Sparkles } from 'lucide-react';
+import type { UsePuzzleEngineReturn } from '../../engine';
+
+interface MovesPanelProps {
+  className?: string;
+  /** When provided, dispatches against the engine — required for the
+   * editor's preview pane which uses a local engine instance instead of
+   * the global puzzleStore. */
+  engine?: UsePuzzleEngineReturn;
+}
+
+/**
+ * Renders the puzzle's `moves[]` as a grid of buttons. Each click dispatches
+ * `applyMove(moveId)`, which atomically applies the move's transform to the
+ * board.
+ *
+ * The panel is only rendered when `puzzle.moves` is non-empty — see
+ * PuzzleShell which conditionally adds the tab. Inside the panel we still
+ * guard for the empty case so the component can be used standalone.
+ */
+export function MovesPanel({ className = '', engine }: MovesPanelProps) {
+  const storePuzzle = usePuzzleStore((s) => s.puzzle);
+  const storeApplyMove = usePuzzleStore((s) => s.applyMove);
+
+  const puzzle = engine?.puzzle ?? storePuzzle;
+  const applyMove = engine?.applyMove ?? storeApplyMove;
+
+  const moves = puzzle?.moves ?? [];
+
+  return (
+    <div className={`flex flex-col overflow-hidden ${className}`}>
+      <div className="flex-shrink-0 px-4 py-3 bg-gradient-to-r from-[var(--surface-raised)] to-[var(--surface-base)] border-b border-border">
+        <h3 className="text-sm font-semibold tracking-wide text-foreground flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-primary" />
+          MOVES
+        </h3>
+        <div className="mt-1 text-xs text-muted-foreground">
+          {moves.length} {moves.length === 1 ? 'move' : 'moves'} available
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto p-3.5 bg-gradient-to-b from-transparent to-background/40">
+        {moves.length === 0 ? (
+          <p className="text-xs text-muted-foreground text-center py-6">
+            This puzzle defines no moves.
+          </p>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+            {moves.map((move) => {
+              if (move.trigger.kind !== 'button') return null;
+              const accent = move.trigger.color;
+              return (
+                <Button
+                  key={move.id}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => applyMove(move.id)}
+                  className="h-12 flex-col gap-1 font-mono text-sm font-bold border-2 hover:bg-primary/10"
+                  style={accent ? { borderColor: accent, color: accent } : undefined}
+                  title={`Move: ${move.id}`}
+                >
+                  {move.trigger.label}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/data/puzzles/index.ts
+++ b/src/data/puzzles/index.ts
@@ -9,3 +9,6 @@ export { BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, NONOGR
 
 // Templates
 export { BLANK_PUZZLE, FIT_ALL_PUZZLE } from './templates';
+
+// Generic-moves engine demos
+export { FOUR_TILE_ROTATION_PUZZLE } from './moves';

--- a/src/data/puzzles/moves.ts
+++ b/src/data/puzzles/moves.ts
@@ -1,0 +1,76 @@
+import type { PuzzleDefinition } from '../../types/puzzle';
+
+// ============================================
+// 4-TILE ROTATION — minimal proof of moves[] + permute
+// ============================================
+//
+// 2×2 board, 4 colored sticker tiles, two buttons that rotate the four
+// tiles CW or CCW around the center. The puzzle is solved when each tile
+// is at its target cell (a 1-move-from-solved scramble is shipped).
+//
+// This is the smallest puzzle that exercises the generic moves engine:
+// a single permute cycle of four positions, with locked pieces (so the
+// player can't shortcut by dragging tiles around).
+//
+export const FOUR_TILE_ROTATION_PUZZLE: PuzzleDefinition = {
+  title: '4-Tile Rotation',
+  description:
+    'Rotate the four colored tiles into their target positions. Pieces are locked — your only tools are the CW and CCW buttons.',
+  viewMode: '2D',
+  lock_pieces: true,
+  board: {
+    dimensions: { width: 2, height: 2, depth: 1 },
+    // Scrambled by one CW step from the solved arrangement, so a single
+    // CCW press solves it.
+    initial_state: [
+      { id: 'yellow', cells: [[0, 0]], color: '#FBB02D' },
+      { id: 'red', cells: [[1, 0]], color: '#D01012' },
+      { id: 'blue', cells: [[1, 1]], color: '#3066BE' },
+      { id: 'green', cells: [[0, 1]], color: '#287F46' },
+    ],
+  },
+  inventory: [],
+  validation_rules: [
+    {
+      type: 'CUSTOM',
+      rule: 'CUSTOM_RULE',
+      params: {
+        label: 'Tiles in target positions',
+        condition: {
+          kind: 'ALL',
+          children: [
+            { kind: 'cells_have_color', cells: [[0, 0]], color: '#D01012' },
+            { kind: 'cells_have_color', cells: [[1, 0]], color: '#3066BE' },
+            { kind: 'cells_have_color', cells: [[1, 1]], color: '#287F46' },
+            { kind: 'cells_have_color', cells: [[0, 1]], color: '#FBB02D' },
+          ],
+        },
+      },
+    },
+  ],
+  moves: [
+    {
+      id: 'cw',
+      trigger: { kind: 'button', label: 'CW ↻', color: '#3066BE' },
+      transform: {
+        kind: 'permute',
+        // The brick at (0,0) → (1,0) → (1,1) → (0,1) → (0,0)
+        cycles: [[[0, 0], [1, 0], [1, 1], [0, 1]]],
+      },
+    },
+    {
+      id: 'ccw',
+      trigger: { kind: 'button', label: 'CCW ↺', color: '#287F46' },
+      transform: {
+        kind: 'permute',
+        // Inverse cycle.
+        cycles: [[[0, 0], [0, 1], [1, 1], [1, 0]]],
+      },
+    },
+  ],
+  metadata: {
+    author: 'engine demo',
+    difficulty: 'easy',
+    tags: ['moves', 'permutation', 'demo'],
+  },
+};

--- a/src/engine/usePuzzleEngine.ts
+++ b/src/engine/usePuzzleEngine.ts
@@ -87,6 +87,9 @@ interface UsePuzzleEngineReturn extends EngineState, EngineActions {
   canUndo: boolean;
   /** Whether redo is available */
   canRedo: boolean;
+  /** Apply a `puzzle.moves[]` move by id. No-op if the move id is unknown
+   * or the transform leaves all positions unchanged. */
+  applyMove: (moveId: string) => void;
 }
 
 // ============================================
@@ -538,6 +541,71 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
   }, [config, board, pushSnapshot]);
 
   // ============================================
+  // GENERIC MOVES (puzzle.moves[])
+  // ============================================
+
+  const applyMove = useCallback((moveId: string) => {
+    const move = puzzle?.moves?.find(m => m.id === moveId);
+    if (!move) return;
+
+    // Pure transform application — matches puzzleStore.applyTransform but
+    // operates on EngineBoard / PlacedPiece (engine's domain) instead of
+    // BoardState / PlacedBrick (store's domain).
+    type Tx = { kind: 'permute'; cycles: [number, number][][] } | { kind: 'sequence'; steps: Tx[] };
+    const applyTx = (pieces: PlacedPiece[], tx: Tx): PlacedPiece[] => {
+      if (tx.kind === 'sequence') {
+        let r = pieces;
+        for (const step of tx.steps) r = applyTx(r, step);
+        return r;
+      }
+      const moved = new Map<string, { x: number; y: number }>();
+      const occupied = new Set(pieces.map(p => `${p.position.x},${p.position.y}`));
+      for (const cycle of tx.cycles) {
+        if (cycle.length < 2) continue;
+        for (let i = 0; i < cycle.length; i++) {
+          const fromKey = `${cycle[i][0]},${cycle[i][1]}`;
+          const to = cycle[(i + 1) % cycle.length];
+          if (occupied.has(fromKey)) moved.set(fromKey, { x: to[0], y: to[1] });
+        }
+      }
+      return pieces.map(p => {
+        const key = `${p.position.x},${p.position.y}`;
+        const dest = moved.get(key);
+        return dest ? { ...p, position: { x: dest.x, y: dest.y, z: p.position.z } } : p;
+      });
+    };
+
+    const nextPieces = applyTx(board.placedPieces, move.transform as Tx);
+    // No-op early-out if nothing actually moved.
+    let changed = false;
+    for (let i = 0; i < nextPieces.length; i++) {
+      const a = nextPieces[i];
+      const b = board.placedPieces[i];
+      if (a.position.x !== b.position.x || a.position.y !== b.position.y) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return;
+
+    // Push undo snapshot.
+    const snapshot: EngineSnapshot = {
+      board: { ...board, placedPieces: [...board.placedPieces] },
+      inventory: new Map(inventory),
+      moveCount,
+    };
+    undoStackRef.current = [...undoStackRef.current.slice(-(MAX_UNDO_HISTORY - 1)), snapshot];
+    redoStackRef.current = [];
+    setUndoLen(undoStackRef.current.length);
+    setRedoLen(0);
+
+    setBoard({ ...board, placedPieces: nextPieces });
+    setMoveCount(moveCount + 1);
+    SoundManager.getInstance().play('slide');
+    haptics.light();
+  }, [puzzle, board, inventory, moveCount]);
+
+  // ============================================
   // SELECTION
   // ============================================
 
@@ -688,6 +756,7 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
     validateBoard,
     resetBoard,
     loadPuzzle,
+    applyMove,
 
     // Undo / Redo
     undo,

--- a/src/store/puzzleStore.ts
+++ b/src/store/puzzleStore.ts
@@ -6,7 +6,8 @@ import {
   ValidationResult,
   DEFAULT_PUZZLE,
   PuzzleDefinitionSchema,
-  SHAPE_LIBRARY
+  SHAPE_LIBRARY,
+  MoveTransform,
 } from '../types/puzzle';
 import { ValidationRegistry, getBrickCells, rotateShape } from '../validation/ValidationRegistry';
 import {
@@ -90,6 +91,9 @@ interface PuzzleStore {
   // Sliding helpers
   getValidSlideDestinationsFor: (instanceId: string) => [number, number][];
   isSlidingPuzzle: () => boolean;
+
+  // Generic moves (puzzle.moves[])
+  applyMove: (moveId: string) => void;
 }
 
 // ============================================
@@ -179,6 +183,47 @@ function engineBoardToBoardState(engine: EngineBoard): BoardState {
     })),
     blockedCells: engine.blockedCells,
   };
+}
+
+/**
+ * Apply a MoveTransform to a list of bricks and return a new list. Pure —
+ * does not mutate inputs. Supports nested `sequence` transforms.
+ *
+ * `permute`: for each cycle, the brick at cycle[i] moves to cycle[(i+1) %
+ * len]. Cells in a cycle that hold no brick are skipped (the next brick in
+ * the cycle simply skips that empty slot). Bricks not referenced by any
+ * cycle stay where they are.
+ */
+function applyTransform(
+  bricks: PlacedBrick[],
+  transform: MoveTransform,
+): PlacedBrick[] {
+  if (transform.kind === 'sequence') {
+    let result = bricks;
+    for (const step of transform.steps) result = applyTransform(result, step);
+    return result;
+  }
+  // permute
+  // Index bricks by their *starting* position so each cycle reads source
+  // positions consistently even if multiple cycles overlap.
+  const byPos = new Map<string, PlacedBrick>();
+  for (const b of bricks) byPos.set(`${b.position.x},${b.position.y}`, b);
+
+  const moved = new Map<string, { x: number; y: number }>();
+  for (const cycle of transform.cycles) {
+    if (cycle.length < 2) continue;
+    for (let i = 0; i < cycle.length; i++) {
+      const fromKey = `${cycle[i][0]},${cycle[i][1]}`;
+      const to = cycle[(i + 1) % cycle.length];
+      if (byPos.has(fromKey)) moved.set(fromKey, { x: to[0], y: to[1] });
+    }
+  }
+
+  return bricks.map(b => {
+    const key = `${b.position.x},${b.position.y}`;
+    const dest = moved.get(key);
+    return dest ? { ...b, position: { x: dest.x, y: dest.y } } : b;
+  });
 }
 
 function setActionError(set: (partial: Partial<PuzzleStore>) => void, message: string) {
@@ -772,6 +817,50 @@ export const usePuzzleStore = create<PuzzleStore>((set, get) => ({
       shakeBoard: false,
       completionProgress: 'normal',
     });
+  },
+
+  // ------------------------------------------
+  // GENERIC MOVES (puzzle.moves[])
+  // ------------------------------------------
+
+  applyMove: (moveId) => {
+    const { puzzle, boardState, inventoryState, undoStack } = get();
+    if (!puzzle?.moves) return;
+    const move = puzzle.moves.find(m => m.id === moveId);
+    if (!move) return;
+
+    const snapshot: BoardSnapshot = {
+      boardState: { ...boardState, placedBricks: [...boardState.placedBricks] },
+      inventoryState: new Map(inventoryState),
+      moveCount: get().moveCount,
+    };
+
+    const nextBricks = applyTransform(boardState.placedBricks, move.transform);
+    // No-op if the transform didn't actually change any position.
+    let changed = nextBricks.length !== boardState.placedBricks.length;
+    if (!changed) {
+      for (let i = 0; i < nextBricks.length; i++) {
+        const a = nextBricks[i];
+        const b = boardState.placedBricks[i];
+        if (a.position.x !== b.position.x || a.position.y !== b.position.y) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) return;
+
+    const newBoardState = { ...boardState, placedBricks: nextBricks };
+    const newMoveCount = get().moveCount + 1;
+    set({
+      boardState: newBoardState,
+      moveCount: newMoveCount,
+      undoStack: [...undoStack.slice(-(MAX_UNDO_HISTORY - 1)), snapshot],
+      redoStack: [],
+      ...computeValidation(puzzle, newBoardState, newMoveCount),
+    });
+    SoundManager.getInstance().play('slide');
+    haptics.light();
   },
 
   // ------------------------------------------

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -223,6 +223,68 @@ export const NonogramHintsSchema = z.object({
 
 export type NonogramHints = z.infer<typeof NonogramHintsSchema>;
 
+// ============================================
+// MOVES (generic action primitive)
+// ============================================
+
+/**
+ * A trigger is the UI affordance that fires a move. Currently only `button`
+ * is implemented — other kinds (drag, keypress, click-cell) can be added
+ * later without touching the engine's apply-move logic.
+ */
+export const MoveTriggerSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('button'),
+    /** Text shown on the button. */
+    label: z.string(),
+    /** Optional accent color (CSS string). The button uses this as a small
+     * dot/border tint — handy for color-coding face turns on a Rubik's cube
+     * or color-coding gear directions. */
+    color: z.string().optional(),
+  }),
+]);
+
+export type MoveTrigger = z.infer<typeof MoveTriggerSchema>;
+
+/**
+ * `permute` — atomic position permutation. Each `cycle` is a list of board
+ * `[x, y]` positions; the brick at cycle[i] moves to cycle[(i+1) % len]. A
+ * single move can contain multiple disjoint cycles (e.g. a Rubik's face turn
+ * cycles 4 corners + 4 edges + 12 adjacent stickers in one move).
+ *
+ * Empty positions in a cycle are skipped — useful for moves that operate on
+ * sparse boards where not every cell holds a piece.
+ *
+ * `sequence` — apply a list of sub-transforms in order. Lets authors compose
+ * complex moves from simpler primitives (e.g. F-turn = reorient + top-row +
+ * unreorient) without writing one fat permutation table.
+ */
+export const MoveTransformSchema: z.ZodType<MoveTransform> = z.lazy(() =>
+  z.discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('permute'),
+      cycles: z.array(z.array(z.tuple([z.number(), z.number()]))),
+    }),
+    z.object({
+      kind: z.literal('sequence'),
+      steps: z.array(MoveTransformSchema),
+    }),
+  ]),
+);
+
+export type MoveTransform =
+  | { kind: 'permute'; cycles: [number, number][][] }
+  | { kind: 'sequence'; steps: MoveTransform[] };
+
+export const MoveSchema = z.object({
+  /** Stable identifier — used for keying, undo/redo grouping, and analytics. */
+  id: z.string(),
+  trigger: MoveTriggerSchema,
+  transform: MoveTransformSchema,
+});
+
+export type Move = z.infer<typeof MoveSchema>;
+
 export const PuzzleDefinitionSchema = z.object({
   puzzle_id: z.string().optional(),
   title: z.string(),
@@ -283,6 +345,21 @@ export const PuzzleDefinitionSchema = z.object({
   subset_stacking: z.boolean().optional(),
   /** Optional custom shape definitions */
   custom_shapes: z.record(z.string(), ShapeDefinitionSchema).optional(),
+  /**
+   * Optional named moves. Renders one button per move; clicking applies the
+   * move's transform to the board state atomically. Use this for puzzles
+   * where the player chooses among a fixed set of operations (Rubik's-style
+   * face turns, gear toggles, lights-out cell flips, etc.) instead of (or
+   * in addition to) free piece movement.
+   */
+  moves: z.array(MoveSchema).optional(),
+  /**
+   * If true, placed pieces cannot be moved, removed, or rotated by direct
+   * user interaction — only `moves[]` can change the board. Use for
+   * Rubik's-style puzzles where the player must operate via the configured
+   * moves, not by dragging individual stickers.
+   */
+  lock_pieces: z.boolean().optional(),
   /** Metadata */
   metadata: z.object({
     author: z.string().optional(),


### PR DESCRIPTION
Foundation for puzzles where the player picks among a fixed set of operations (Rubik's-style face turns, gears, lights-out, sliding-tile permutations). Adds a small plug-in primitive so any of these can be authored in JSON without touching the engine.

## Summary

- New `moves[]` field on `PuzzleDefinition` — array of `{ id, trigger, transform }`.
- `trigger`: discriminated union, currently `button` (label + optional accent color).
- `transform`: discriminated union, ships `permute` (cycles of positions — each cell rotates to the next) and `sequence` (chain sub-transforms).
- `lock_pieces: true` disables direct user interaction with pieces, so the only legal operations are the configured moves. Wired into both 2D `Renderer2D` and 3D `PuzzleScene`.
- `applyMove(id)` available on both `puzzleStore` and `usePuzzleEngine` so the editor preview and the gallery both work.
- New `MovesPanel` adds a third right-sidebar tab that auto-appears when the puzzle has moves and stays hidden otherwise (existing puzzles look identical).
- Demo puzzle `FOUR_TILE_ROTATION_PUZZLE` (2×2 board, four sticker tiles, CW/CCW buttons, `cells_have_color` win check) proves the engine end-to-end.

## Why permute (not multi-axis rotation)

Spent several rounds discussing whether a Rubik's-style cube needs multi-color brick schema and 3-axis rotation. Conclusion: in an unfolded 2D representation, every face turn collapses to a permutation table. No rotation primitive needed, no multi-sticker brick schema needed. Each sticker is a one-color tile; each face turn cycles 12-20 sticker positions.

A 2×2 Pocket Cube authored on this engine is just data — six permutation tables + a custom-code validator. Will land in a follow-up PR.

## Test plan
- [ ] In the editor, paste a JSON with `moves[]` (e.g. the FOUR_TILE_ROTATION_PUZZLE schema) — the Moves tab appears, buttons render with the configured labels/colors.
- [ ] Click a button — pieces permute according to the cycle; undo/redo work.
- [ ] `lock_pieces: true` prevents drag/click on pieces (only the buttons move state).
- [ ] Open a puzzle *without* `moves[]` (any default puzzle, Klotski, etc.) — no Moves tab; flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)