### PR TITLE
Pocket Cube + 3D Rubik's renderer (rides on the moves engine)

### DIFF
--- a/src/app/PuzzleShell.tsx
+++ b/src/app/PuzzleShell.tsx
@@ -6,6 +6,7 @@ import { PuzzleRenderer, ViewModeIndicator } from '../components/renderer';
 import { InventoryPanel } from '../components/ui/InventoryPanel';
 import { ValidationPanel } from '../components/ui/ValidationPanel';
 import { HtmlSandboxModal } from '../components/ui/HtmlSandboxModal';
+import { MovesPanel } from '../components/ui/MovesPanel';
 import { PuzzleInfoPopup } from '../components/ui/PuzzleInfoPopup';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/shadcn/tabs';
 import { Button } from '../components/ui/shadcn/button';
@@ -162,27 +163,44 @@ function SidePanel({ puzzle, showInfo, setShowInfo, activeEngine, validationResu
           html={puzzle.clue_html}
         />
       )}
-      <Tabs defaultValue="inventory" className="flex-1 min-h-0 flex flex-col gap-0 px-2 pb-2">
-        <div className="shrink-0 pb-1.5">
-          <TabsList variant="line" className="w-full h-9 grid grid-cols-2 rounded-lg bg-[var(--surface-raised)] border border-border">
-            <TabsTrigger value="inventory" className="text-xs">Inventory</TabsTrigger>
-            <TabsTrigger value="validation" className="text-xs gap-1.5">
-              Validation
-              {validationResults.length > 0 && (
-                <span className={`text-[9px] font-mono px-1 py-0 rounded ${isComplete ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'}`}>
-                  {validationResults.filter(r => r.isValid).length}/{validationResults.length}
-                </span>
-              )}
-            </TabsTrigger>
-          </TabsList>
-        </div>
-        <TabsContent value="inventory" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
-          <InventoryPanel className="h-full" engine={activeEngine} />
-        </TabsContent>
-        <TabsContent value="validation" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
-          <ValidationPanel className="h-full" engine={activeEngine} />
-        </TabsContent>
-      </Tabs>
+      {(() => {
+        const hasMoves = (puzzle?.moves?.length ?? 0) > 0;
+        const defaultTab = hasMoves ? 'moves' : 'inventory';
+        return (
+          <Tabs defaultValue={defaultTab} className="flex-1 min-h-0 flex flex-col gap-0 px-2 pb-2">
+            <div className="shrink-0 pb-1.5">
+              <TabsList
+                variant="line"
+                className={`w-full h-9 grid ${hasMoves ? 'grid-cols-3' : 'grid-cols-2'} rounded-lg bg-[var(--surface-raised)] border border-border`}
+              >
+                {hasMoves && (
+                  <TabsTrigger value="moves" className="text-xs">Moves</TabsTrigger>
+                )}
+                <TabsTrigger value="inventory" className="text-xs">Inventory</TabsTrigger>
+                <TabsTrigger value="validation" className="text-xs gap-1.5">
+                  Validation
+                  {validationResults.length > 0 && (
+                    <span className={`text-[9px] font-mono px-1 py-0 rounded ${isComplete ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'}`}>
+                      {validationResults.filter(r => r.isValid).length}/{validationResults.length}
+                    </span>
+                  )}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+            {hasMoves && (
+              <TabsContent value="moves" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+                <MovesPanel className="h-full" engine={activeEngine} />
+              </TabsContent>
+            )}
+            <TabsContent value="inventory" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+              <InventoryPanel className="h-full" engine={activeEngine} />
+            </TabsContent>
+            <TabsContent value="validation" className="flex-1 min-h-0 overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)]">
+              <ValidationPanel className="h-full" engine={activeEngine} />
+            </TabsContent>
+          </Tabs>
+        );
+      })()}
     </div>
   );
 }

--- a/src/app/PuzzleShell.tsx
+++ b/src/app/PuzzleShell.tsx
@@ -33,6 +33,9 @@ const RuleBuilderPanel = React.lazy(() =>
 const PuzzleScene = React.lazy(() =>
   import('../components/3d/PuzzleScene').then(m => ({ default: m.PuzzleScene }))
 );
+const RubiksCubeScene = React.lazy(() =>
+  import('../components/3d/RubiksCubeScene').then(m => ({ default: m.RubiksCubeScene }))
+);
 const CongratulationsPopup = React.lazy(() =>
   import('../components/ui/CongratulationsPopup').then(m => ({ default: m.CongratulationsPopup }))
 );
@@ -71,15 +74,32 @@ function EditorPanel() {
 }
 
 function RendererPanel({ is2D, engine, viewMode }: { is2D: boolean; engine: ReturnType<typeof usePuzzleEngine>; viewMode: '2D' | '3D' }) {
+  // `render_as` lets a puzzle opt into a domain-specific 3D view (e.g. the
+  // Rubik's cube renderer reads sticker positions from the engine's
+  // unfolded 2D state and paints them on cubie faces). When set, the
+  // renderer dispatch ignores viewMode.
+  const renderAs = engine.puzzle?.render_as;
+
+  let renderer: React.ReactNode;
+  if (renderAs === 'rubiks_2x2') {
+    renderer = (
+      <Suspense fallback={<SceneSkeleton />}>
+        <RubiksCubeScene engine={engine} />
+      </Suspense>
+    );
+  } else if (is2D) {
+    renderer = <PuzzleRenderer engine={engine} />;
+  } else {
+    renderer = (
+      <Suspense fallback={<SceneSkeleton />}>
+        <PuzzleScene />
+      </Suspense>
+    );
+  }
+
   return (
     <div className="h-full bg-[radial-gradient(circle_at_30%_20%,rgba(101,143,222,0.16),rgba(8,12,20,0.15)_35%,rgba(8,12,20,0.9)_100%)] relative">
-      {is2D ? (
-        <PuzzleRenderer engine={engine} />
-      ) : (
-        <Suspense fallback={<SceneSkeleton />}>
-          <PuzzleScene />
-        </Suspense>
-      )}
+      {renderer}
       <div className="absolute top-3 right-3 z-10">
         <ViewModeIndicator viewMode={viewMode} />
       </div>

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -728,14 +728,16 @@ function DragDropManager({ setOrbitEnabled }: { setOrbitEnabled: (enabled: boole
         // When a placed brick is selected for moving, ALL bricks (including the selected one) 
         // become non-interactive so clicks pass through to the board for movement
         const isThisBrickInSelectedStack = selectedStackIds.has(brick.instanceId);
-        // In dragNdrop mode, pressing any unselected placed brick should be
-        // able to start a new drag — so non-selected bricks stay interactive
-        // even when another brick is currently selected. The selected stack
-        // itself stays non-interactive so pointer events fall through to the
-        // cells beneath during the drag.
-        const isInteractive = dragNdrop
+        // lock_pieces disables direct user interaction with pieces — the
+        // board can only be changed via puzzle.moves[] in that mode.
+        // In dragNdrop mode, the selected stack stays non-interactive so
+        // pointer events fall through to the cells beneath during the drag,
+        // but other placed bricks stay interactive so the user can press a
+        // different one to switch selection mid-flow.
+        const piecesLocked = puzzle?.lock_pieces ?? false;
+        const isInteractive = !piecesLocked && (dragNdrop
           ? !selectedInventoryBrick && !isThisBrickInSelectedStack
-          : !selectedInventoryBrick && !selectedPlacedBrick;
+          : !selectedInventoryBrick && !selectedPlacedBrick);
         const isThisBrickInvalid = invalidBrickIds.has(brick.instanceId);
 
         return (

--- a/src/components/3d/RubiksCubeScene.tsx
+++ b/src/components/3d/RubiksCubeScene.tsx
@@ -1,0 +1,242 @@
+import { Suspense } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, PerspectiveCamera, RoundedBox, ContactShadows } from '@react-three/drei';
+import * as THREE from 'three';
+import { usePuzzleStore } from '../../store/puzzleStore';
+import type { UsePuzzleEngineReturn } from '../../engine';
+
+/**
+ * Renders a 2×2 Rubik's cube (Pocket Cube) in 3D from a puzzle whose state
+ * lives on an unfolded 2D cross. Each sticker tile in the puzzle has a 2D
+ * (x, y) position; this scene maps that position to (cubie, face) via a
+ * fixed lookup and paints a thin colored quad on the matching cubie face.
+ *
+ * The mapping below assumes the standard Pocket Cube layout:
+ *
+ *           (2,0) (3,0)
+ *           (2,1) (3,1)
+ *   (0,2) (1,2) (2,2) (3,2) (4,2) (5,2) (6,2) (7,2)
+ *   (0,3) (1,3) (2,3) (3,3) (4,3) (5,3) (6,3) (7,3)
+ *           (2,4) (3,4)
+ *           (2,5) (3,5)
+ *
+ * The engine permutations (puzzle.moves[]) shuffle bricks among these
+ * positions; this renderer is a pure projection of that state — no engine
+ * involvement.
+ */
+
+type Axis = '+x' | '-x' | '+y' | '-y' | '+z' | '-z';
+
+// (unfolded x, unfolded y) → (cubie xyz, face axis)
+// Cubie coordinates are in {0, 1}^3 (8 corners of a 2×2 cube).
+// xyz convention: +x = R, +y = U, +z = F.
+const STICKER_MAP: Record<string, { cubie: [number, number, number]; face: Axis }> = {
+  // U face (+y) — viewed from above, B at top of view, F at bottom
+  '2,0': { cubie: [0, 1, 0], face: '+y' }, // U-B-L
+  '3,0': { cubie: [1, 1, 0], face: '+y' }, // U-B-R
+  '2,1': { cubie: [0, 1, 1], face: '+y' }, // U-F-L
+  '3,1': { cubie: [1, 1, 1], face: '+y' }, // U-F-R
+  // L face (-x) — viewed from the left, U up, B right (since L is unfolded from F's left)
+  '0,2': { cubie: [0, 1, 0], face: '-x' }, // U-B-L
+  '1,2': { cubie: [0, 1, 1], face: '-x' }, // U-F-L
+  '0,3': { cubie: [0, 0, 0], face: '-x' }, // D-B-L
+  '1,3': { cubie: [0, 0, 1], face: '-x' }, // D-F-L
+  // F face (+z)
+  '2,2': { cubie: [0, 1, 1], face: '+z' }, // U-F-L
+  '3,2': { cubie: [1, 1, 1], face: '+z' }, // U-F-R
+  '2,3': { cubie: [0, 0, 1], face: '+z' }, // D-F-L
+  '3,3': { cubie: [1, 0, 1], face: '+z' }, // D-F-R
+  // R face (+x) — unfolded after F
+  '4,2': { cubie: [1, 1, 1], face: '+x' }, // U-F-R
+  '5,2': { cubie: [1, 1, 0], face: '+x' }, // U-B-R
+  '4,3': { cubie: [1, 0, 1], face: '+x' }, // D-F-R
+  '5,3': { cubie: [1, 0, 0], face: '+x' }, // D-B-R
+  // B face (-z) — unfolded after R, so the unfolded-right side is closer to L
+  '6,2': { cubie: [1, 1, 0], face: '-z' }, // U-B-R
+  '7,2': { cubie: [0, 1, 0], face: '-z' }, // U-B-L
+  '6,3': { cubie: [1, 0, 0], face: '-z' }, // D-B-R
+  '7,3': { cubie: [0, 0, 0], face: '-z' }, // D-B-L
+  // D face (-y)
+  '2,4': { cubie: [0, 0, 1], face: '-y' }, // D-F-L
+  '3,4': { cubie: [1, 0, 1], face: '-y' }, // D-F-R
+  '2,5': { cubie: [0, 0, 0], face: '-y' }, // D-B-L
+  '3,5': { cubie: [1, 0, 0], face: '-y' }, // D-B-R
+};
+
+const CUBIE_SIZE = 0.96;
+const STICKER_SIZE = 0.86;
+const STICKER_THICKNESS = 0.02;
+
+// World-position offset for a sticker on a cubie's given face. Sits just
+// outside the cubie surface so it doesn't z-fight with the cubie body.
+function stickerOffset(face: Axis): [number, number, number] {
+  const out = CUBIE_SIZE / 2 + STICKER_THICKNESS / 2;
+  switch (face) {
+    case '+x': return [out, 0, 0];
+    case '-x': return [-out, 0, 0];
+    case '+y': return [0, out, 0];
+    case '-y': return [0, -out, 0];
+    case '+z': return [0, 0, out];
+    case '-z': return [0, 0, -out];
+  }
+}
+
+function stickerDimensions(face: Axis): [number, number, number] {
+  switch (face) {
+    case '+x':
+    case '-x': return [STICKER_THICKNESS, STICKER_SIZE, STICKER_SIZE];
+    case '+y':
+    case '-y': return [STICKER_SIZE, STICKER_THICKNESS, STICKER_SIZE];
+    case '+z':
+    case '-z': return [STICKER_SIZE, STICKER_SIZE, STICKER_THICKNESS];
+  }
+}
+
+// Center the 2×2 cubie cluster on the origin: cubie indices {0,1} → world
+// positions {-0.5, +0.5} (so the cube spans x,y,z ∈ [-1, 1]).
+function cubieWorldPosition(cubie: [number, number, number]): [number, number, number] {
+  return [cubie[0] - 0.5, cubie[1] - 0.5, cubie[2] - 0.5];
+}
+
+interface RubiksCubeSceneProps {
+  /** Optional engine source. When present, sticker positions are read from
+   * `engine.board.placedPieces`; otherwise we fall back to the global
+   * puzzle store. Mirrors the dual-source pattern used by MovesPanel. */
+  engine?: UsePuzzleEngineReturn;
+}
+
+function CubieBody({ position }: { position: [number, number, number] }) {
+  return (
+    <RoundedBox
+      args={[CUBIE_SIZE, CUBIE_SIZE, CUBIE_SIZE]}
+      radius={0.04}
+      smoothness={3}
+      position={position}
+      castShadow
+      receiveShadow
+    >
+      <meshPhysicalMaterial color="#1a1a1a" roughness={0.4} metalness={0.05} />
+    </RoundedBox>
+  );
+}
+
+function Sticker({
+  cubieWorld,
+  face,
+  color,
+}: {
+  cubieWorld: [number, number, number];
+  face: Axis;
+  color: string;
+}) {
+  const off = stickerOffset(face);
+  const pos: [number, number, number] = [
+    cubieWorld[0] + off[0],
+    cubieWorld[1] + off[1],
+    cubieWorld[2] + off[2],
+  ];
+  return (
+    <mesh position={pos} castShadow receiveShadow>
+      <boxGeometry args={stickerDimensions(face)} />
+      <meshPhysicalMaterial
+        color={color}
+        roughness={0.35}
+        metalness={0.05}
+        clearcoat={0.7}
+        clearcoatRoughness={0.25}
+      />
+    </mesh>
+  );
+}
+
+function CubeContent({ engine }: { engine?: UsePuzzleEngineReturn }) {
+  // Same dual-source pattern as MovesPanel — preview pane in the editor
+  // feeds an engine; the gallery uses the store.
+  const storeBricks = usePuzzleStore(s => s.boardState.placedBricks);
+  const bricks = engine?.board.placedPieces ?? storeBricks;
+
+  // 8 cubie positions in {0,1}^3.
+  const cubies: [number, number, number][] = [];
+  for (let cx = 0; cx <= 1; cx++)
+    for (let cy = 0; cy <= 1; cy++)
+      for (let cz = 0; cz <= 1; cz++)
+        cubies.push([cx, cy, cz]);
+
+  return (
+    <>
+      {cubies.map((c, i) => (
+        <CubieBody key={`cubie-${i}`} position={cubieWorldPosition(c)} />
+      ))}
+      {bricks.map(brick => {
+        const key = `${brick.position.x},${brick.position.y}`;
+        const slot = STICKER_MAP[key];
+        if (!slot) return null;
+        return (
+          <Sticker
+            key={brick.instanceId}
+            cubieWorld={cubieWorldPosition(slot.cubie)}
+            face={slot.face}
+            color={brick.color}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export function RubiksCubeScene({ engine }: RubiksCubeSceneProps) {
+  return (
+    <div className="w-full h-full" style={{ backgroundColor: '#0f1520' }}>
+      <Canvas
+        shadows
+        dpr={[1, 1.75]}
+        gl={{ antialias: true, alpha: false, powerPreference: 'high-performance' }}
+        onCreated={({ gl, scene }) => {
+          gl.toneMapping = THREE.ACESFilmicToneMapping;
+          gl.toneMappingExposure = 1.0;
+          gl.outputColorSpace = THREE.SRGBColorSpace;
+          scene.background = new THREE.Color('#0f1520');
+        }}
+      >
+        <PerspectiveCamera makeDefault position={[3, 2.5, 3.5]} fov={40} />
+        <OrbitControls
+          makeDefault
+          enablePan={false}
+          enableZoom={true}
+          enableRotate={true}
+          enableDamping
+          dampingFactor={0.08}
+          minDistance={2.5}
+          maxDistance={8}
+          target={[0, 0, 0]}
+        />
+
+        <ambientLight intensity={0.5} />
+        <hemisphereLight intensity={0.4} color="#ffffff" groundColor="#404040" />
+        <directionalLight
+          position={[5, 8, 5]}
+          intensity={1.1}
+          castShadow
+          shadow-mapSize={[1024, 1024]}
+          shadow-camera-far={20}
+          shadow-camera-left={-5}
+          shadow-camera-right={5}
+          shadow-camera-top={5}
+          shadow-camera-bottom={-5}
+        />
+        <directionalLight position={[-4, 3, -4]} intensity={0.4} />
+
+        <Suspense fallback={null}>
+          <CubeContent engine={engine} />
+          <ContactShadows
+            position={[0, -1.2, 0]}
+            opacity={0.5}
+            scale={6}
+            blur={2.4}
+            far={4}
+          />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -358,14 +358,16 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
             const isClickedPiece = selectedPieceId === piece.instanceId;
             const isInSelectedStack = selectedStackIds.has(piece.instanceId);
             const isHovered = hoveredPieceId === piece.instanceId;
-            // In dragNdrop mode, pieces stay interactive even when another
-            // piece OR an inventory tile is selected — pressing a piece
-            // switches selection to it. Only the selected piece's own stack
-            // passes pointer events through so cells underneath can track
-            // hover during the drag.
-            const isInteractive = dragNdrop
+            // lock_pieces disables direct user interaction with pieces — the
+            // board can only be changed via puzzle.moves[] in that mode.
+            // In dragNdrop mode, only the selected stack passes pointer
+            // events through so cells underneath can track hover during the
+            // drag; other pieces stay interactive so pressing a different
+            // one switches selection.
+            const piecesLocked = puzzle?.lock_pieces ?? false;
+            const isInteractive = !piecesLocked && (dragNdrop
               ? !isInSelectedStack
-              : !selectedInventoryPiece && !selectedPlacedPiece;
+              : !selectedInventoryPiece && !selectedPlacedPiece);
             const isPieceInvalid = invalidPieceIds.has(piece.instanceId);
 
             const pieceValidMoves = isClickedPiece && config.movementRule === 'SLIDING_ONLY'

--- a/src/components/ui/MovesPanel.tsx
+++ b/src/components/ui/MovesPanel.tsx
@@ -1,0 +1,73 @@
+import { usePuzzleStore } from '../../store/puzzleStore';
+import { Button } from '../ui/shadcn/button';
+import { Sparkles } from 'lucide-react';
+import type { UsePuzzleEngineReturn } from '../../engine';
+
+interface MovesPanelProps {
+  className?: string;
+  /** When provided, dispatches against the engine — required for the
+   * editor's preview pane which uses a local engine instance instead of
+   * the global puzzleStore. */
+  engine?: UsePuzzleEngineReturn;
+}
+
+/**
+ * Renders the puzzle's `moves[]` as a grid of buttons. Each click dispatches
+ * `applyMove(moveId)`, which atomically applies the move's transform to the
+ * board.
+ *
+ * The panel is only rendered when `puzzle.moves` is non-empty — see
+ * PuzzleShell which conditionally adds the tab. Inside the panel we still
+ * guard for the empty case so the component can be used standalone.
+ */
+export function MovesPanel({ className = '', engine }: MovesPanelProps) {
+  const storePuzzle = usePuzzleStore((s) => s.puzzle);
+  const storeApplyMove = usePuzzleStore((s) => s.applyMove);
+
+  const puzzle = engine?.puzzle ?? storePuzzle;
+  const applyMove = engine?.applyMove ?? storeApplyMove;
+
+  const moves = puzzle?.moves ?? [];
+
+  return (
+    <div className={`flex flex-col overflow-hidden ${className}`}>
+      <div className="flex-shrink-0 px-4 py-3 bg-gradient-to-r from-[var(--surface-raised)] to-[var(--surface-base)] border-b border-border">
+        <h3 className="text-sm font-semibold tracking-wide text-foreground flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-primary" />
+          MOVES
+        </h3>
+        <div className="mt-1 text-xs text-muted-foreground">
+          {moves.length} {moves.length === 1 ? 'move' : 'moves'} available
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto p-3.5 bg-gradient-to-b from-transparent to-background/40">
+        {moves.length === 0 ? (
+          <p className="text-xs text-muted-foreground text-center py-6">
+            This puzzle defines no moves.
+          </p>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+            {moves.map((move) => {
+              if (move.trigger.kind !== 'button') return null;
+              const accent = move.trigger.color;
+              return (
+                <Button
+                  key={move.id}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => applyMove(move.id)}
+                  className="h-12 flex-col gap-1 font-mono text-sm font-bold border-2 hover:bg-primary/10"
+                  style={accent ? { borderColor: accent, color: accent } : undefined}
+                  title={`Move: ${move.id}`}
+                >
+                  {move.trigger.label}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/config/puzzleCategories.ts
+++ b/src/config/puzzleCategories.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PUZZLE, FIT_ALL_PUZZLE, BLANK_PUZZLE, SLIDER_PUZZLE, GRID_PUZZLE, BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, COLORFUL_COVERAGE_PUZZLE } from '../types/puzzle';
-import { KLOTSKI_RED_DONKEY, KLOTSKI_CROSSWAY, PEN_CHALLENGE_PUZZLE, NONOGRAM_PUZZLE, NONOGRAM_PUZZLE_2 } from '../types/puzzle';
+import { KLOTSKI_RED_DONKEY, KLOTSKI_CROSSWAY, PEN_CHALLENGE_PUZZLE, NONOGRAM_PUZZLE, NONOGRAM_PUZZLE_2, POCKET_CUBE_PUZZLE } from '../types/puzzle';
 import type { LucideIcon } from 'lucide-react';
 import { Grid3x3, LayoutGrid, Move, Binary, Lightbulb, Brain } from 'lucide-react';
 
@@ -62,6 +62,7 @@ export const PUZZLE_CATEGORIES: PuzzleCategory[] = [
     icon: Lightbulb,
     puzzles: [
       { id: 'pen-challenge', label: 'Pen Challenge', puzzle: PEN_CHALLENGE_PUZZLE, is3D: false },
+      { id: 'pocket-cube', label: 'Pocket Cube', puzzle: POCKET_CUBE_PUZZLE, is3D: true },
     ],
   },
   {

--- a/src/data/puzzles/index.ts
+++ b/src/data/puzzles/index.ts
@@ -12,3 +12,4 @@ export { BLANK_PUZZLE, FIT_ALL_PUZZLE } from './templates';
 
 // Generic-moves engine demos
 export { FOUR_TILE_ROTATION_PUZZLE } from './moves';
+export { POCKET_CUBE_PUZZLE } from './rubiks';

--- a/src/data/puzzles/index.ts
+++ b/src/data/puzzles/index.ts
@@ -9,3 +9,6 @@ export { BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, NONOGR
 
 // Templates
 export { BLANK_PUZZLE, FIT_ALL_PUZZLE } from './templates';
+
+// Generic-moves engine demos
+export { FOUR_TILE_ROTATION_PUZZLE } from './moves';

--- a/src/data/puzzles/moves.ts
+++ b/src/data/puzzles/moves.ts
@@ -1,0 +1,76 @@
+import type { PuzzleDefinition } from '../../types/puzzle';
+
+// ============================================
+// 4-TILE ROTATION — minimal proof of moves[] + permute
+// ============================================
+//
+// 2×2 board, 4 colored sticker tiles, two buttons that rotate the four
+// tiles CW or CCW around the center. The puzzle is solved when each tile
+// is at its target cell (a 1-move-from-solved scramble is shipped).
+//
+// This is the smallest puzzle that exercises the generic moves engine:
+// a single permute cycle of four positions, with locked pieces (so the
+// player can't shortcut by dragging tiles around).
+//
+export const FOUR_TILE_ROTATION_PUZZLE: PuzzleDefinition = {
+  title: '4-Tile Rotation',
+  description:
+    'Rotate the four colored tiles into their target positions. Pieces are locked — your only tools are the CW and CCW buttons.',
+  viewMode: '2D',
+  lock_pieces: true,
+  board: {
+    dimensions: { width: 2, height: 2, depth: 1 },
+    // Scrambled by one CW step from the solved arrangement, so a single
+    // CCW press solves it.
+    initial_state: [
+      { id: 'yellow', cells: [[0, 0]], color: '#FBB02D' },
+      { id: 'red', cells: [[1, 0]], color: '#D01012' },
+      { id: 'blue', cells: [[1, 1]], color: '#3066BE' },
+      { id: 'green', cells: [[0, 1]], color: '#287F46' },
+    ],
+  },
+  inventory: [],
+  validation_rules: [
+    {
+      type: 'CUSTOM',
+      rule: 'CUSTOM_RULE',
+      params: {
+        label: 'Tiles in target positions',
+        condition: {
+          kind: 'ALL',
+          children: [
+            { kind: 'cells_have_color', cells: [[0, 0]], color: '#D01012' },
+            { kind: 'cells_have_color', cells: [[1, 0]], color: '#3066BE' },
+            { kind: 'cells_have_color', cells: [[1, 1]], color: '#287F46' },
+            { kind: 'cells_have_color', cells: [[0, 1]], color: '#FBB02D' },
+          ],
+        },
+      },
+    },
+  ],
+  moves: [
+    {
+      id: 'cw',
+      trigger: { kind: 'button', label: 'CW ↻', color: '#3066BE' },
+      transform: {
+        kind: 'permute',
+        // The brick at (0,0) → (1,0) → (1,1) → (0,1) → (0,0)
+        cycles: [[[0, 0], [1, 0], [1, 1], [0, 1]]],
+      },
+    },
+    {
+      id: 'ccw',
+      trigger: { kind: 'button', label: 'CCW ↺', color: '#287F46' },
+      transform: {
+        kind: 'permute',
+        // Inverse cycle.
+        cycles: [[[0, 0], [0, 1], [1, 1], [1, 0]]],
+      },
+    },
+  ],
+  metadata: {
+    author: 'engine demo',
+    difficulty: 'easy',
+    tags: ['moves', 'permutation', 'demo'],
+  },
+};

--- a/src/data/puzzles/rubiks.ts
+++ b/src/data/puzzles/rubiks.ts
@@ -44,8 +44,9 @@ const ORANGE = '#FF5800';
 export const POCKET_CUBE_PUZZLE: PuzzleDefinition = {
   title: 'Pocket Cube',
   description:
-    "2×2 Rubik's cube unfolded. Each button rotates one face 90° clockwise — click three times for an inverse turn. Solve by aligning each face to a single color.",
+    "2×2 Rubik's cube. Each button rotates one face 90° clockwise — click three times for an inverse turn. Solve by aligning each face to a single color. Drag to orbit the camera.",
   viewMode: '2D',
+  render_as: 'rubiks_2x2',
   lock_pieces: true,
   board: {
     dimensions: { width: 8, height: 6, depth: 1 },

--- a/src/data/puzzles/rubiks.ts
+++ b/src/data/puzzles/rubiks.ts
@@ -1,0 +1,204 @@
+import type { PuzzleDefinition } from '../../types/puzzle';
+
+// ============================================
+// POCKET CUBE — 2×2 Rubik's, unfolded 2D layout
+// ============================================
+//
+// Layout (8 wide × 6 tall, 24 sticker cells + 24 blocked):
+//
+//          U U . . . .
+//          U U . . . .
+//   L L F F R R B B
+//   L L F F R R B B
+//          D D . . . .
+//          D D . . . .
+//
+// Each sticker is a 1×1 single-color tile. Each face turn is one
+// `permute` transform: one 4-cycle for the face's own stickers + two
+// 4-cycles for the 8 side stickers that ride along the turn.
+//
+// Sticker ↔ cubie mapping (positions of each cubie's 3 stickers):
+//   U-F-L: U₂=(2,1), F₀=(2,2), L₁=(1,2)
+//   U-F-R: U₃=(3,1), F₁=(3,2), R₀=(4,2)
+//   U-B-L: U₀=(2,0), B₁=(7,2), L₀=(0,2)
+//   U-B-R: U₁=(3,0), B₀=(6,2), R₁=(5,2)
+//   D-F-L: D₀=(2,4), F₂=(2,3), L₃=(1,3)
+//   D-F-R: D₁=(3,4), F₃=(3,3), R₂=(4,3)
+//   D-B-L: D₂=(2,5), B₃=(7,3), L₂=(0,3)
+//   D-B-R: D₃=(3,5), B₂=(6,3), R₃=(5,3)
+//
+// Colors (standard Western/WCA scheme):
+//   U = white, D = yellow, F = green, B = blue, R = red, L = orange.
+//
+// Initial state is one R-turn away from solved — three more R presses
+// solves it. Just enough scramble to prove all 6 face turns end up
+// producing a uniform-face state, without making manual testing tedious.
+
+const WHITE  = '#FFFFFF';
+const YELLOW = '#FFD500';
+const GREEN  = '#009E60';
+const BLUE   = '#3D81F6';
+const RED    = '#C41E3A';
+const ORANGE = '#FF5800';
+
+export const POCKET_CUBE_PUZZLE: PuzzleDefinition = {
+  title: 'Pocket Cube',
+  description:
+    "2×2 Rubik's cube unfolded. Each button rotates one face 90° clockwise — click three times for an inverse turn. Solve by aligning each face to a single color.",
+  viewMode: '2D',
+  lock_pieces: true,
+  board: {
+    dimensions: { width: 8, height: 6, depth: 1 },
+    blocked_cells: [
+      [0, 0], [1, 0], [4, 0], [5, 0], [6, 0], [7, 0],
+      [0, 1], [1, 1], [4, 1], [5, 1], [6, 1], [7, 1],
+      [0, 4], [1, 4], [4, 4], [5, 4], [6, 4], [7, 4],
+      [0, 5], [1, 5], [4, 5], [5, 5], [6, 5], [7, 5],
+    ],
+    // One R-turn away from solved.
+    // R-turn side rings (CW from outside R):
+    //   ring1: (3,1) → (6,2) → (3,5) → (3,3) → (3,1)
+    //   ring2: (3,2) → (3,0) → (6,3) → (3,4) → (3,2)
+    // So after one R-turn applied to solved:
+    //   (3,1)=green (was F), (3,3)=yellow (was D), (3,5)=blue (was B),
+    //   (6,2)=white (was U), (3,2)=yellow (was D), (3,4)=blue (was B),
+    //   (6,3)=white (was U), (3,0)=green (was F).
+    initial_state: [
+      // U face — 2 swapped with green
+      { id: 'U0', cells: [[2, 0]], color: WHITE },
+      { id: 'U1', cells: [[3, 0]], color: GREEN  },
+      { id: 'U2', cells: [[2, 1]], color: WHITE },
+      { id: 'U3', cells: [[3, 1]], color: GREEN  },
+      // L face — untouched by R, all orange
+      { id: 'L0', cells: [[0, 2]], color: ORANGE },
+      { id: 'L1', cells: [[1, 2]], color: ORANGE },
+      { id: 'L2', cells: [[0, 3]], color: ORANGE },
+      { id: 'L3', cells: [[1, 3]], color: ORANGE },
+      // F face — right column swapped with yellow
+      { id: 'F0', cells: [[2, 2]], color: GREEN  },
+      { id: 'F1', cells: [[3, 2]], color: YELLOW },
+      { id: 'F2', cells: [[2, 3]], color: GREEN  },
+      { id: 'F3', cells: [[3, 3]], color: YELLOW },
+      // R face — still all red after its own turn
+      { id: 'R0', cells: [[4, 2]], color: RED },
+      { id: 'R1', cells: [[5, 2]], color: RED },
+      { id: 'R2', cells: [[4, 3]], color: RED },
+      { id: 'R3', cells: [[5, 3]], color: RED },
+      // B face — left column swapped with white
+      { id: 'B0', cells: [[6, 2]], color: WHITE },
+      { id: 'B1', cells: [[7, 2]], color: BLUE  },
+      { id: 'B2', cells: [[6, 3]], color: WHITE },
+      { id: 'B3', cells: [[7, 3]], color: BLUE  },
+      // D face — right column swapped with blue
+      { id: 'D0', cells: [[2, 4]], color: YELLOW },
+      { id: 'D1', cells: [[3, 4]], color: BLUE   },
+      { id: 'D2', cells: [[2, 5]], color: YELLOW },
+      { id: 'D3', cells: [[3, 5]], color: BLUE   },
+    ],
+    // Paint the empty surround so the cross silhouette reads clearly.
+    cell_colors: [],
+  },
+  inventory: [],
+  validation_rules: [
+    {
+      type: 'CUSTOM',
+      rule: 'CUSTOM_RULE',
+      params: {
+        label: 'Each face is a single color',
+        condition: {
+          kind: 'ALL',
+          children: [
+            { kind: 'cells_have_color', cells: [[2, 0], [3, 0], [2, 1], [3, 1]], color: WHITE  },
+            { kind: 'cells_have_color', cells: [[2, 4], [3, 4], [2, 5], [3, 5]], color: YELLOW },
+            { kind: 'cells_have_color', cells: [[2, 2], [3, 2], [2, 3], [3, 3]], color: GREEN  },
+            { kind: 'cells_have_color', cells: [[6, 2], [7, 2], [6, 3], [7, 3]], color: BLUE   },
+            { kind: 'cells_have_color', cells: [[4, 2], [5, 2], [4, 3], [5, 3]], color: RED    },
+            { kind: 'cells_have_color', cells: [[0, 2], [1, 2], [0, 3], [1, 3]], color: ORANGE },
+          ],
+        },
+      },
+    },
+  ],
+  // Each face turn is derived geometrically (R_axis(±90°) on the layer's
+  // 4 cubies + sticker direction rotation). The 3 cycles per move are:
+  // (a) the face's own stickers, (b) two rings of 4 side stickers.
+  moves: [
+    {
+      id: 'U',
+      trigger: { kind: 'button', label: 'U', color: WHITE },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[2, 1], [2, 0], [3, 0], [3, 1]],
+          [[2, 2], [0, 2], [6, 2], [4, 2]],
+          [[1, 2], [7, 2], [5, 2], [3, 2]],
+        ],
+      },
+    },
+    {
+      id: 'D',
+      trigger: { kind: 'button', label: 'D', color: YELLOW },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[2, 4], [3, 4], [3, 5], [2, 5]],
+          [[2, 3], [4, 3], [6, 3], [0, 3]],
+          [[1, 3], [3, 3], [5, 3], [7, 3]],
+        ],
+      },
+    },
+    {
+      id: 'F',
+      trigger: { kind: 'button', label: 'F', color: GREEN },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[2, 2], [3, 2], [3, 3], [2, 3]],
+          [[2, 1], [4, 2], [3, 4], [1, 3]],
+          [[1, 2], [3, 1], [4, 3], [2, 4]],
+        ],
+      },
+    },
+    {
+      id: 'B',
+      trigger: { kind: 'button', label: 'B', color: BLUE },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[7, 2], [7, 3], [6, 3], [6, 2]],
+          [[2, 0], [0, 3], [3, 5], [5, 2]],
+          [[0, 2], [2, 5], [5, 3], [3, 0]],
+        ],
+      },
+    },
+    {
+      id: 'R',
+      trigger: { kind: 'button', label: 'R', color: RED },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[4, 2], [5, 2], [5, 3], [4, 3]],
+          [[3, 1], [6, 2], [3, 5], [3, 3]],
+          [[3, 2], [3, 0], [6, 3], [3, 4]],
+        ],
+      },
+    },
+    {
+      id: 'L',
+      trigger: { kind: 'button', label: 'L', color: ORANGE },
+      transform: {
+        kind: 'permute',
+        cycles: [
+          [[1, 2], [1, 3], [0, 3], [0, 2]],
+          [[2, 1], [2, 3], [2, 5], [7, 2]],
+          [[2, 2], [2, 4], [7, 3], [2, 0]],
+        ],
+      },
+    },
+  ],
+  metadata: {
+    author: 'engine demo',
+    difficulty: 'easy',
+    tags: ['rubiks', 'permutation', 'moves'],
+  },
+};

--- a/src/engine/usePuzzleEngine.ts
+++ b/src/engine/usePuzzleEngine.ts
@@ -87,6 +87,9 @@ interface UsePuzzleEngineReturn extends EngineState, EngineActions {
   canUndo: boolean;
   /** Whether redo is available */
   canRedo: boolean;
+  /** Apply a `puzzle.moves[]` move by id. No-op if the move id is unknown
+   * or the transform leaves all positions unchanged. */
+  applyMove: (moveId: string) => void;
 }
 
 // ============================================
@@ -538,6 +541,71 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
   }, [config, board, pushSnapshot]);
 
   // ============================================
+  // GENERIC MOVES (puzzle.moves[])
+  // ============================================
+
+  const applyMove = useCallback((moveId: string) => {
+    const move = puzzle?.moves?.find(m => m.id === moveId);
+    if (!move) return;
+
+    // Pure transform application — matches puzzleStore.applyTransform but
+    // operates on EngineBoard / PlacedPiece (engine's domain) instead of
+    // BoardState / PlacedBrick (store's domain).
+    type Tx = { kind: 'permute'; cycles: [number, number][][] } | { kind: 'sequence'; steps: Tx[] };
+    const applyTx = (pieces: PlacedPiece[], tx: Tx): PlacedPiece[] => {
+      if (tx.kind === 'sequence') {
+        let r = pieces;
+        for (const step of tx.steps) r = applyTx(r, step);
+        return r;
+      }
+      const moved = new Map<string, { x: number; y: number }>();
+      const occupied = new Set(pieces.map(p => `${p.position.x},${p.position.y}`));
+      for (const cycle of tx.cycles) {
+        if (cycle.length < 2) continue;
+        for (let i = 0; i < cycle.length; i++) {
+          const fromKey = `${cycle[i][0]},${cycle[i][1]}`;
+          const to = cycle[(i + 1) % cycle.length];
+          if (occupied.has(fromKey)) moved.set(fromKey, { x: to[0], y: to[1] });
+        }
+      }
+      return pieces.map(p => {
+        const key = `${p.position.x},${p.position.y}`;
+        const dest = moved.get(key);
+        return dest ? { ...p, position: { x: dest.x, y: dest.y, z: p.position.z } } : p;
+      });
+    };
+
+    const nextPieces = applyTx(board.placedPieces, move.transform as Tx);
+    // No-op early-out if nothing actually moved.
+    let changed = false;
+    for (let i = 0; i < nextPieces.length; i++) {
+      const a = nextPieces[i];
+      const b = board.placedPieces[i];
+      if (a.position.x !== b.position.x || a.position.y !== b.position.y) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) return;
+
+    // Push undo snapshot.
+    const snapshot: EngineSnapshot = {
+      board: { ...board, placedPieces: [...board.placedPieces] },
+      inventory: new Map(inventory),
+      moveCount,
+    };
+    undoStackRef.current = [...undoStackRef.current.slice(-(MAX_UNDO_HISTORY - 1)), snapshot];
+    redoStackRef.current = [];
+    setUndoLen(undoStackRef.current.length);
+    setRedoLen(0);
+
+    setBoard({ ...board, placedPieces: nextPieces });
+    setMoveCount(moveCount + 1);
+    SoundManager.getInstance().play('slide');
+    haptics.light();
+  }, [puzzle, board, inventory, moveCount]);
+
+  // ============================================
   // SELECTION
   // ============================================
 
@@ -688,6 +756,7 @@ export function usePuzzleEngine(options: UsePuzzleEngineOptions): UsePuzzleEngin
     validateBoard,
     resetBoard,
     loadPuzzle,
+    applyMove,
 
     // Undo / Redo
     undo,

--- a/src/store/puzzleStore.ts
+++ b/src/store/puzzleStore.ts
@@ -6,7 +6,8 @@ import {
   ValidationResult,
   DEFAULT_PUZZLE,
   PuzzleDefinitionSchema,
-  SHAPE_LIBRARY
+  SHAPE_LIBRARY,
+  MoveTransform,
 } from '../types/puzzle';
 import { ValidationRegistry, getBrickCells, rotateShape } from '../validation/ValidationRegistry';
 import {
@@ -90,6 +91,9 @@ interface PuzzleStore {
   // Sliding helpers
   getValidSlideDestinationsFor: (instanceId: string) => [number, number][];
   isSlidingPuzzle: () => boolean;
+
+  // Generic moves (puzzle.moves[])
+  applyMove: (moveId: string) => void;
 }
 
 // ============================================
@@ -179,6 +183,47 @@ function engineBoardToBoardState(engine: EngineBoard): BoardState {
     })),
     blockedCells: engine.blockedCells,
   };
+}
+
+/**
+ * Apply a MoveTransform to a list of bricks and return a new list. Pure —
+ * does not mutate inputs. Supports nested `sequence` transforms.
+ *
+ * `permute`: for each cycle, the brick at cycle[i] moves to cycle[(i+1) %
+ * len]. Cells in a cycle that hold no brick are skipped (the next brick in
+ * the cycle simply skips that empty slot). Bricks not referenced by any
+ * cycle stay where they are.
+ */
+function applyTransform(
+  bricks: PlacedBrick[],
+  transform: MoveTransform,
+): PlacedBrick[] {
+  if (transform.kind === 'sequence') {
+    let result = bricks;
+    for (const step of transform.steps) result = applyTransform(result, step);
+    return result;
+  }
+  // permute
+  // Index bricks by their *starting* position so each cycle reads source
+  // positions consistently even if multiple cycles overlap.
+  const byPos = new Map<string, PlacedBrick>();
+  for (const b of bricks) byPos.set(`${b.position.x},${b.position.y}`, b);
+
+  const moved = new Map<string, { x: number; y: number }>();
+  for (const cycle of transform.cycles) {
+    if (cycle.length < 2) continue;
+    for (let i = 0; i < cycle.length; i++) {
+      const fromKey = `${cycle[i][0]},${cycle[i][1]}`;
+      const to = cycle[(i + 1) % cycle.length];
+      if (byPos.has(fromKey)) moved.set(fromKey, { x: to[0], y: to[1] });
+    }
+  }
+
+  return bricks.map(b => {
+    const key = `${b.position.x},${b.position.y}`;
+    const dest = moved.get(key);
+    return dest ? { ...b, position: { x: dest.x, y: dest.y } } : b;
+  });
 }
 
 function setActionError(set: (partial: Partial<PuzzleStore>) => void, message: string) {
@@ -772,6 +817,50 @@ export const usePuzzleStore = create<PuzzleStore>((set, get) => ({
       shakeBoard: false,
       completionProgress: 'normal',
     });
+  },
+
+  // ------------------------------------------
+  // GENERIC MOVES (puzzle.moves[])
+  // ------------------------------------------
+
+  applyMove: (moveId) => {
+    const { puzzle, boardState, inventoryState, undoStack } = get();
+    if (!puzzle?.moves) return;
+    const move = puzzle.moves.find(m => m.id === moveId);
+    if (!move) return;
+
+    const snapshot: BoardSnapshot = {
+      boardState: { ...boardState, placedBricks: [...boardState.placedBricks] },
+      inventoryState: new Map(inventoryState),
+      moveCount: get().moveCount,
+    };
+
+    const nextBricks = applyTransform(boardState.placedBricks, move.transform);
+    // No-op if the transform didn't actually change any position.
+    let changed = nextBricks.length !== boardState.placedBricks.length;
+    if (!changed) {
+      for (let i = 0; i < nextBricks.length; i++) {
+        const a = nextBricks[i];
+        const b = boardState.placedBricks[i];
+        if (a.position.x !== b.position.x || a.position.y !== b.position.y) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) return;
+
+    const newBoardState = { ...boardState, placedBricks: nextBricks };
+    const newMoveCount = get().moveCount + 1;
+    set({
+      boardState: newBoardState,
+      moveCount: newMoveCount,
+      undoStack: [...undoStack.slice(-(MAX_UNDO_HISTORY - 1)), snapshot],
+      redoStack: [],
+      ...computeValidation(puzzle, newBoardState, newMoveCount),
+    });
+    SoundManager.getInstance().play('slide');
+    haptics.light();
   },
 
   // ------------------------------------------

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -450,3 +450,4 @@ export { DEFAULT_PUZZLE, COLORFUL_COVERAGE_PUZZLE, GRID_PUZZLE } from '../data/p
 export { SLIDER_PUZZLE, KLOTSKI_RED_DONKEY, KLOTSKI_CROSSWAY, PEN_CHALLENGE_PUZZLE } from '../data/puzzles/slider';
 export { BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, NONOGRAM_PUZZLE, NONOGRAM_PUZZLE_2 } from '../data/puzzles/pattern';
 export { BLANK_PUZZLE, FIT_ALL_PUZZLE } from '../data/puzzles/templates';
+export { POCKET_CUBE_PUZZLE } from '../data/puzzles/rubiks';

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -223,6 +223,68 @@ export const NonogramHintsSchema = z.object({
 
 export type NonogramHints = z.infer<typeof NonogramHintsSchema>;
 
+// ============================================
+// MOVES (generic action primitive)
+// ============================================
+
+/**
+ * A trigger is the UI affordance that fires a move. Currently only `button`
+ * is implemented — other kinds (drag, keypress, click-cell) can be added
+ * later without touching the engine's apply-move logic.
+ */
+export const MoveTriggerSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('button'),
+    /** Text shown on the button. */
+    label: z.string(),
+    /** Optional accent color (CSS string). The button uses this as a small
+     * dot/border tint — handy for color-coding face turns on a Rubik's cube
+     * or color-coding gear directions. */
+    color: z.string().optional(),
+  }),
+]);
+
+export type MoveTrigger = z.infer<typeof MoveTriggerSchema>;
+
+/**
+ * `permute` — atomic position permutation. Each `cycle` is a list of board
+ * `[x, y]` positions; the brick at cycle[i] moves to cycle[(i+1) % len]. A
+ * single move can contain multiple disjoint cycles (e.g. a Rubik's face turn
+ * cycles 4 corners + 4 edges + 12 adjacent stickers in one move).
+ *
+ * Empty positions in a cycle are skipped — useful for moves that operate on
+ * sparse boards where not every cell holds a piece.
+ *
+ * `sequence` — apply a list of sub-transforms in order. Lets authors compose
+ * complex moves from simpler primitives (e.g. F-turn = reorient + top-row +
+ * unreorient) without writing one fat permutation table.
+ */
+export const MoveTransformSchema: z.ZodType<MoveTransform> = z.lazy(() =>
+  z.discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('permute'),
+      cycles: z.array(z.array(z.tuple([z.number(), z.number()]))),
+    }),
+    z.object({
+      kind: z.literal('sequence'),
+      steps: z.array(MoveTransformSchema),
+    }),
+  ]),
+);
+
+export type MoveTransform =
+  | { kind: 'permute'; cycles: [number, number][][] }
+  | { kind: 'sequence'; steps: MoveTransform[] };
+
+export const MoveSchema = z.object({
+  /** Stable identifier — used for keying, undo/redo grouping, and analytics. */
+  id: z.string(),
+  trigger: MoveTriggerSchema,
+  transform: MoveTransformSchema,
+});
+
+export type Move = z.infer<typeof MoveSchema>;
+
 export const PuzzleDefinitionSchema = z.object({
   puzzle_id: z.string().optional(),
   title: z.string(),
@@ -301,6 +363,21 @@ export const PuzzleDefinitionSchema = z.object({
   dragNdrop: z.boolean().optional(),
   /** Optional custom shape definitions */
   custom_shapes: z.record(z.string(), ShapeDefinitionSchema).optional(),
+  /**
+   * Optional named moves. Renders one button per move; clicking applies the
+   * move's transform to the board state atomically. Use this for puzzles
+   * where the player chooses among a fixed set of operations (Rubik's-style
+   * face turns, gear toggles, lights-out cell flips, etc.) instead of (or
+   * in addition to) free piece movement.
+   */
+  moves: z.array(MoveSchema).optional(),
+  /**
+   * If true, placed pieces cannot be moved, removed, or rotated by direct
+   * user interaction — only `moves[]` can change the board. Use for
+   * Rubik's-style puzzles where the player must operate via the configured
+   * moves, not by dragging individual stickers.
+   */
+  lock_pieces: z.boolean().optional(),
   /** Metadata */
   metadata: z.object({
     author: z.string().optional(),

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -378,6 +378,18 @@ export const PuzzleDefinitionSchema = z.object({
    * moves, not by dragging individual stickers.
    */
   lock_pieces: z.boolean().optional(),
+  /**
+   * Optional custom renderer override. When set, the renderer dispatch
+   * uses the named view instead of the standard 2D/3D pair derived from
+   * `viewMode`. The engine state (positions, permutations) is unchanged;
+   * the renderer just paints the same state in a domain-specific way.
+   *
+   *   - `'rubiks_2x2'`: 3D unit-cube view with 8 cubies + sticker tiles
+   *     painted on cubie faces, driven by an unfolded-cross → (cubie, face)
+   *     mapping. Pair with `viewMode: '2D'` so the engine treats the
+   *     puzzle as 2D for movement purposes.
+   */
+  render_as: z.enum(['rubiks_2x2']).optional(),
   /** Metadata */
   metadata: z.object({
     author: z.string().optional(),


### PR DESCRIPTION
Closes #63.

Stacks on #69 (`feat/generic-moves`). Adds the 2×2 Rubik's puzzle as data + a real 3D cube renderer for it. No engine changes — sticker positions still live as 2D unfolded coordinates and are still moved by `permute` transforms; the new scene just maps each position to (cubie, face) and paints a colored quad on the right face of a 3D cubie.

## Summary

- New puzzle: **Pocket Cube** (2×2 Rubik's). 24 single-color sticker tiles + 24 blocked surround cells on an 8×6 unfolded-cross layout. Six face-turn buttons (U/D/L/R/F/B), each a `permute` with three 4-cycles (face stickers + two side rings). Ships scrambled one R-turn away from solved.
- New schema field: `render_as?: 'rubiks_2x2'`. Renderer dispatch checks this *before* viewMode, so the puzzle keeps `viewMode: '2D'` (for engine purposes) while opting into a 3D paint.
- New component: `RubiksCubeScene` — R3F Canvas, 8 cubie bodies, sticker quads on faces, OrbitControls for camera. The unfolded → (cubie, face) lookup is a constant table.
- Validation reuses the existing `cells_have_color` rule, one per face — solved when each face is uniform.

## Why permute (recap)

Multi-color cubies + multi-axis rotation aren't needed. Every face turn is one permutation table (~12-21 positions cycling). The user sees a 3D cube, the engine sees an unfolded 2D grid, the renderer bridges the two.

## Test plan
- [ ] Load the Pocket Cube via the editor (paste the JSON or run from data/puzzles).
- [ ] Verify it renders as a 3D cube with the scrambled colors visible (U has white + green, etc.).
- [ ] Drag to orbit — confirm hidden faces (D, B, L) show their colors.
- [ ] Click `R` three times — the "Puzzle Solved!" modal appears, each face is uniform.
- [ ] Confirm other puzzles (no `render_as`) are unaffected.

## Notes for future
- The 3D paint is currently a "snap" on each move — no rotation animation.
- 3×3 Rubik's drops in by adding `'rubiks_3x3'` to the enum + a 54-entry STICKER_MAP + the longer permutation tables. No engine work needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)