### PR TITLE
Tutorial + Hint slots with sandboxed HTML modal renderer

### DIFF
--- a/src/app/PuzzleShell.tsx
+++ b/src/app/PuzzleShell.tsx
@@ -5,6 +5,7 @@ import { ResizablePanels } from '../components/layout/ResizablePanels';
 import { PuzzleRenderer, ViewModeIndicator } from '../components/renderer';
 import { InventoryPanel } from '../components/ui/InventoryPanel';
 import { ValidationPanel } from '../components/ui/ValidationPanel';
+import { HtmlSandboxModal } from '../components/ui/HtmlSandboxModal';
 import { PuzzleInfoPopup } from '../components/ui/PuzzleInfoPopup';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/shadcn/tabs';
 import { Button } from '../components/ui/shadcn/button';
@@ -18,7 +19,7 @@ import { PUZZLE_CATEGORIES, BLANK_PUZZLE } from '../config/puzzleCategories';
 import { recordCompletion } from '../store/completionTracker';
 import { useUserStore } from '../store/userStore';
 
-import { Save, Upload, ArchiveRestore, BookOpen, PanelLeftOpen, PanelRightOpen } from 'lucide-react';
+import { Save, Upload, ArchiveRestore, BookOpen, PanelLeftOpen, PanelRightOpen, GraduationCap, Lightbulb } from 'lucide-react';
 import { CellPickerOverlay } from '../components/editor/ruleBuilder/CellPickerOverlay';
 
 // Lazy-loaded heavy components
@@ -92,12 +93,40 @@ function SidePanel({ puzzle, showInfo, setShowInfo, activeEngine, validationResu
   isComplete: boolean; flipped?: boolean;
 }) {
   const togglePanelFlip = useEditorViewStore((s) => s.togglePanelFlip);
+  const [showTutorial, setShowTutorial] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+  const hasTutorial = typeof puzzle?.tutorial_html === 'string' && puzzle.tutorial_html.length > 0;
+  const hasHint = typeof puzzle?.clue_html === 'string' && puzzle.clue_html.length > 0;
   return (
     <div className={`h-full min-w-[300px] bg-gradient-to-b from-card to-background ${flipped ? 'border-r' : 'border-l'} border-border shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] flex flex-col`}>
       <div className="shrink-0 px-3 pt-2 pb-1 flex items-center gap-1.5">
         <span className="text-[11px] font-semibold text-muted-foreground truncate flex-1">
           {puzzle?.title}
         </span>
+        {hasTutorial && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px] gap-1.5 shrink-0"
+            onClick={() => setShowTutorial(true)}
+            title="Open the puzzle tutorial"
+          >
+            <GraduationCap className="w-3 h-3" />
+            Tutorial
+          </Button>
+        )}
+        {hasHint && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px] gap-1.5 shrink-0"
+            onClick={() => setShowHint(true)}
+            title="Show a hint for this puzzle"
+          >
+            <Lightbulb className="w-3 h-3" />
+            Hint
+          </Button>
+        )}
         <Button
           variant={showInfo ? 'default' : 'outline'}
           size="sm"
@@ -117,6 +146,22 @@ function SidePanel({ puzzle, showInfo, setShowInfo, activeEngine, validationResu
           {flipped ? <PanelRightOpen className="w-3.5 h-3.5" /> : <PanelLeftOpen className="w-3.5 h-3.5" />}
         </Button>
       </div>
+      {hasTutorial && (
+        <HtmlSandboxModal
+          open={showTutorial}
+          onOpenChange={setShowTutorial}
+          title="Tutorial"
+          html={puzzle.tutorial_html}
+        />
+      )}
+      {hasHint && (
+        <HtmlSandboxModal
+          open={showHint}
+          onOpenChange={setShowHint}
+          title="Hint"
+          html={puzzle.clue_html}
+        />
+      )}
       <Tabs defaultValue="inventory" className="flex-1 min-h-0 flex flex-col gap-0 px-2 pb-2">
         <div className="shrink-0 pb-1.5">
           <TabsList variant="line" className="w-full h-9 grid grid-cols-2 rounded-lg bg-[var(--surface-raised)] border border-border">

--- a/src/components/editor/PuzzleEditor.tsx
+++ b/src/components/editor/PuzzleEditor.tsx
@@ -22,6 +22,14 @@ loader.config({ monaco });
 import { PuzzleDefinitionSchema } from '../../types/puzzle';
 import { Button } from '../ui/shadcn/button';
 import { Badge } from '../ui/shadcn/badge';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from '../ui/shadcn/dropdown-menu';
 
 // JSON Schema for Monaco intellisense
 const puzzleJsonSchema = {
@@ -252,8 +260,24 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
     return () => { if (debounceRef.current) window.clearTimeout(debounceRef.current); };
   }, []);
 
-  // ---- Upload HTML or JPEG description ----
+  // ---- Upload HTML or JPEG ----
+  // The slot to write into is selected via the Upload dropdown before the
+  // file picker opens; the ref carries that choice through to the change
+  // handler since the native <input type=file> doesn't carry extra data.
+  type UploadTarget = 'description_html' | 'tutorial_html' | 'clue_html' | 'description_image';
   const uploadInputRef = useRef<HTMLInputElement>(null);
+  const uploadTargetRef = useRef<UploadTarget>('description_html');
+
+  const openUploadFor = useCallback((target: UploadTarget) => {
+    uploadTargetRef.current = target;
+    // Restrict the file picker to the appropriate type for the chosen slot.
+    if (uploadInputRef.current) {
+      uploadInputRef.current.accept = target === 'description_image'
+        ? '.jpg,.jpeg,image/jpeg'
+        : '.html,.htm,text/html';
+      uploadInputRef.current.click();
+    }
+  }, []);
 
   const handleUploadChosen = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -268,19 +292,19 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
       return;
     }
 
-    const isHtml = /\.html?$/i.test(file.name) || file.type === 'text/html';
-    const isJpeg = /\.jpe?g$/i.test(file.name) || file.type === 'image/jpeg';
-
-    if (isHtml) {
-      parsed.description_html = await file.text();
-    } else if (isJpeg) {
+    const target = uploadTargetRef.current;
+    if (target === 'description_image') {
+      const isJpeg = /\.jpe?g$/i.test(file.name) || file.type === 'image/jpeg';
+      if (!isJpeg) return;
       const buf = await file.arrayBuffer();
       const bytes = new Uint8Array(buf);
       let bin = '';
       for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
       parsed.description_image = `data:image/jpeg;base64,${btoa(bin)}`;
     } else {
-      return; // unsupported
+      const isHtml = /\.html?$/i.test(file.name) || file.type === 'text/html';
+      if (!isHtml) return;
+      parsed[target] = await file.text();
     }
 
     const next = JSON.stringify(parsed, null, 2);
@@ -314,19 +338,39 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
           <input
             ref={uploadInputRef}
             type="file"
-            accept=".html,.htm,text/html,.jpg,.jpeg,image/jpeg"
+            accept=".html,.htm,text/html"
             className="hidden"
             onChange={handleUploadChosen}
           />
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 text-xs gap-1.5"
-            onClick={() => uploadInputRef.current?.click()}
-            title="Attach an HTML file (sandboxed) or JPEG image to the description"
-          >
-            Upload
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs gap-1.5"
+                title="Attach HTML (sandboxed) to a description / tutorial / hint slot, or a JPEG to the description image"
+              >
+                Upload
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuLabel className="text-xs">HTML (sandboxed)</DropdownMenuLabel>
+              <DropdownMenuItem onClick={() => openUploadFor('description_html')}>
+                Description
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => openUploadFor('tutorial_html')}>
+                Tutorial
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => openUploadFor('clue_html')}>
+                Hint
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs">Image</DropdownMenuLabel>
+              <DropdownMenuItem onClick={() => openUploadFor('description_image')}>
+                Description image (JPEG)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/ui/HtmlSandboxModal.tsx
+++ b/src/components/ui/HtmlSandboxModal.tsx
@@ -1,0 +1,47 @@
+import { Dialog, DialogContent, DialogTitle } from './shadcn/dialog';
+
+interface HtmlSandboxModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Modal title shown above the iframe. */
+  title: string;
+  /** HTML string rendered inside a sandboxed iframe. */
+  html: string;
+}
+
+/**
+ * Fixed-size centered modal that renders author-provided HTML inside a
+ * `sandbox=""` iframe. The frame dimensions are hardcoded — adversarial
+ * CSS in the embedded HTML cannot resize the modal or break out of it.
+ *
+ * The `sandbox=""` attribute (empty value, not absent) maximally
+ * restricts the iframe: no scripts, no forms, no same-origin, no popups,
+ * no top-level navigation. Authors get styled HTML; the host page stays
+ * isolated.
+ *
+ * Used by both the Tutorial button (`tutorial_html`) and the Hint button
+ * (`clue_html`). Same renderer, same guarantees.
+ */
+export function HtmlSandboxModal({ open, onOpenChange, title, html }: HtmlSandboxModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton
+        className="!max-w-[720px] !w-[720px] gap-3 p-4"
+        style={{ height: 520 }}
+      >
+        <DialogTitle className="text-base">{title}</DialogTitle>
+        <iframe
+          title={title}
+          srcDoc={html}
+          sandbox=""
+          // Hardcoded dimensions — `sandbox=""` already blocks scripts,
+          // and the explicit width/height means CSS inside the iframe
+          // can't grow the frame itself.
+          className="w-full rounded-lg border border-border bg-background"
+          style={{ height: 440 }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/types/puzzle.ts
+++ b/src/types/puzzle.ts
@@ -237,6 +237,16 @@ export const PuzzleDefinitionSchema = z.object({
    * authored explainers, diagrams, or styled instructions. Populated via
    * the "Upload" button in the puzzle editor. */
   description_html: z.string().optional(),
+  /** Optional HTML tutorial / game-play explainer. When set, a
+   * "Tutorial" button appears in the puzzle controls; clicking it opens
+   * the HTML in a fixed-size centered modal. Rendered inside the same
+   * `sandbox=""` iframe as `description_html` — no scripts, no
+   * navigation, no top-level access. Frame dimensions are hardcoded so
+   * adversarial CSS can't resize the modal. */
+  tutorial_html: z.string().optional(),
+  /** Optional HTML clue / hint shown via a "Hint" button during play.
+   * Same sandboxing and fixed-size modal rules as `tutorial_html`. */
+  clue_html: z.string().optional(),
   /** Optional image (data URL, e.g. JPEG) rendered below the description.
    * Populated via the "Upload" button in the puzzle editor. */
   description_image: z.string().optional(),


### PR DESCRIPTION
Closes #65.

Gera asked for a way to upload/embed HTML that shows clues during play and explains gameplay in a tutorial. The existing `description_html` only had one slot and lived inline in the info panel. This adds two new slots and a fixed-size modal renderer that author HTML can't escape.

## Summary

- Schema: `tutorial_html?: string` and `clue_html?: string` on `PuzzleDefinition`.
- New `HtmlSandboxModal` — 720×520 centered modal with a 440px-tall iframe (`sandbox=""`). Hardcoded dimensions mean author CSS can't grow the frame; the empty `sandbox` attribute blocks scripts, navigation, forms, and same-origin access.
- `PuzzleShell.SidePanel`: shows a **Tutorial** / **Hint** button next to "Rules & Controls" only when the puzzle defines the matching slot. Existing puzzles look identical.
- `PuzzleEditor` Upload: replaced the single button with a dropdown — author picks **Description / Tutorial / Hint / Image (JPEG)** before the file picker opens. The native input's `accept` filter is set per-slot.

## Verified

- Tutorial modal renders author HTML with the author's CSS (heading color, font, list bullets) inside the sandbox.
- Embedded `<script>document.body.style.background='red'</script>` was correctly blocked — background remained the default.
- Hint modal opens via its own button and renders separately.
- Puzzle without either slot shows neither button.

## Test plan
- [ ] Paste a puzzle with `tutorial_html` (and no `clue_html`) — only the Tutorial button appears.
- [ ] Paste a puzzle with `clue_html` (and no `tutorial_html`) — only the Hint button appears.
- [ ] Paste a puzzle with both — both buttons appear.
- [ ] In the editor, Upload menu has four slot options; each opens a file picker filtered to HTML or JPEG appropriately.
- [ ] Attempt to break out of the iframe with `<script>`, `<iframe>`, `<form action="...">`, `<a target="_top">` — all blocked by `sandbox=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)