### PR TITLE
Fix stacked-brick pickup and add SPA fallback rewrite

### DIFF
--- a/src/components/3d/PolyominoBrick.tsx
+++ b/src/components/3d/PolyominoBrick.tsx
@@ -299,11 +299,22 @@ export function PolyominoBrick({
   };
 
   // In dragNdrop mode, pressing a brick selects it immediately so the
-  // subsequent drag (and release on a target cell) commits a move. We do
-  // NOT stop propagation — the scene-group's onPointerDown handler also
-  // needs the event to record the drag start position.
-  const handlePointerDown = (_event: ThreeEvent<PointerEvent>) => {
+  // subsequent drag (and release on a target cell) commits a move.
+  //
+  // R3F dispatches pointerdown to every intersected mesh (closest first),
+  // so a stacked column hits the top brick then the bottom brick — without
+  // dedup, the last (bottom) brick's onSelect would overwrite the first
+  // and the user would always grab the wrong piece. We tag the native
+  // event on the first brick that claims it, so the bottom brick bails.
+  // We deliberately don't call event.stopPropagation() — the scene-group's
+  // onPointerDown still needs to fire to record drag-start and disable
+  // OrbitControls in the same React event tick (otherwise the camera
+  // grabs the gesture).
+  const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
     if (!interactive || !dragNdrop) return;
+    const ne = event.nativeEvent as PointerEvent & { __brickClaimed?: boolean };
+    if (ne.__brickClaimed) return;
+    ne.__brickClaimed = true;
     onSelect?.();
   };
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "devCommand": "npx vite --port $PORT",
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/[[...route]]" }
+    { "source": "/api/(.*)", "destination": "/api/[[...route]]" },
+    { "source": "/((?!api/|@|src/|node_modules/|assets/|.*\\..*).*)", "destination": "/index.html" }
   ],
   "functions": {
     "api/[[...route]].ts": {


### PR DESCRIPTION
## Summary
- **Tower of Hanoi top piece grab**: dragging the top of a stack always selected the bottom brick. R3F dispatches pointerdown to every intersected mesh closest-first, so each brick's `onSelect` ran and the last (bottom) won. Tag the native event with a claim flag in `PolyominoBrick.handlePointerDown` so only the topmost intersected brick selects. Propagation still bubbles to the scene group, which is required so `handleScenePointerDown` can disable OrbitControls — otherwise the camera grabs the gesture instead of the brick.
- **404: NOT_FOUND on refresh / login**: `vercel.json` only rewrote `/api/*`. Any deep client route (`/puzzle/:slug`, `/profile/:userId`, Clerk's `/sso-callback`) returned the platform 404 on refresh. Added an SPA catch-all rewrite to `/index.html`, with exclusions for `/api`, Vite virtual paths (`@`, `src/`, `node_modules/`, `assets/`), and any request with a file extension — so `vercel dev` doesn't rewrite Vite's dev asset requests to HTML.

## Test plan
- [ ] Open the Pocket Cube / any Hanoi-style puzzle, click the top of a stack — top brick lifts, not the bottom.
- [ ] Drag an already-placed brick across the board — the brick moves and the camera does NOT orbit during the drag.
- [ ] Hard-refresh on a `/puzzle/:slug` URL — page loads instead of 404.
- [ ] Click "Sign in" and complete Clerk flow — no 404 on callback.
- [ ] `vercel dev` — Vite assets still load (no `index.html` being parsed as JS error).