### PR TITLE
Add "Acyclic Shadows" plugin puzzle + 3D view controls and admin gating

### DIFF
--- a/public/plugin-sandbox.html
+++ b/public/plugin-sandbox.html
@@ -110,6 +110,7 @@
             post({ source: 'lpe-plugin', type: 'STATE', solved: false, progress: verdict().progress, moveCount: moveCount, message: String((e && e.message) || e) });
           }
         },
+        params: cfg.params,
         helpers: { rng: Math.random }
       };
 

--- a/src/__tests__/runtime/acyclicShadowsPlugin.test.ts
+++ b/src/__tests__/runtime/acyclicShadowsPlugin.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ACYCLIC_SHADOWS_PLUGIN_SOURCE } from '../../runtime/plugin/examples/acyclicShadowsPlugin';
+
+/**
+ * Evaluates the EXACT author module source (the artifact that runs in the
+ * sandbox) and exercises its pure logic. The flagship gate is that the embedded
+ * Rickard length-24 loop actually satisfies isSolved — i.e. the win-check both
+ * recognises a single closed loop AND certifies that all three orthogonal
+ * shadows are acyclic. The trap cases (a unit square, disjoint loops, a branch)
+ * prove the four projection/loop fixes are real, not decorative.
+ */
+
+interface State { n: number; edges: string[] }
+interface Move { type: string; key?: string; edges?: string[] }
+interface Shadow { acyclic: boolean }
+interface AcyclicPlugin {
+  initialState(ctx: { params?: Record<string, unknown> }): State;
+  applyMove(state: State, move: Move): State;
+  isSolved(state: State): { solved: boolean; progress: number; message: string };
+  legalMoves(state: State): Move[];
+  _rickardEdges(): string[];
+  _analyze(edges: string[]): { loop: boolean; shadows: Shadow[]; acyclic: number };
+  _isSingleLoop(edges: string[]): boolean;
+  _latticeEdges(n: number): string[];
+}
+
+let plugin: AcyclicPlugin;
+
+beforeAll(() => {
+  const body = ACYCLIC_SHADOWS_PLUGIN_SOURCE.replace('export default ACYCLIC;', 'return ACYCLIC;');
+  plugin = new Function(body)() as AcyclicPlugin;
+});
+
+// canonical unit-edge key, matching the module's ekey()
+function vkey(p: number[]) { return `${p[0]},${p[1]},${p[2]}`; }
+function less3(a: number[], b: number[]) {
+  if (a[0] !== b[0]) return a[0] < b[0];
+  if (a[1] !== b[1]) return a[1] < b[1];
+  return a[2] < b[2];
+}
+function ekey(a: number[], b: number[]) {
+  return less3(a, b) ? `${vkey(a)}|${vkey(b)}` : `${vkey(b)}|${vkey(a)}`;
+}
+function loopEdges(verts: number[][]) {
+  return verts.map((v, i) => ekey(v, verts[(i + 1) % verts.length]));
+}
+
+describe('Acyclic Shadows plugin — the embedded Rickard solution', () => {
+  it('is a single closed loop of exactly 24 edges', () => {
+    const sol = plugin._rickardEdges();
+    expect(sol).toHaveLength(24);
+    expect(new Set(sol).size).toBe(24); // no duplicate edges
+    expect(plugin._isSingleLoop(sol)).toBe(true);
+  });
+
+  it('has all three orthogonal shadows acyclic (the whole point)', () => {
+    const a = plugin._analyze(plugin._rickardEdges());
+    expect(a.loop).toBe(true);
+    expect(a.acyclic).toBe(3);
+    expect(a.shadows.every((s) => s.acyclic)).toBe(true);
+  });
+
+  it('reports solved with full progress via isSolved', () => {
+    const v = plugin.isSolved({ n: 3, edges: plugin._rickardEdges() });
+    expect(v.solved).toBe(true);
+    expect(v.progress).toBe(1);
+  });
+
+  it("initialState start:'rickard' is already solved; default start is not", () => {
+    const solved = plugin.initialState({ params: { start: 'rickard' } });
+    expect(plugin.isSolved(solved).solved).toBe(true);
+    const empty = plugin.initialState({ params: {} });
+    expect(empty.edges).toHaveLength(0);
+    expect(plugin.isSolved(empty).solved).toBe(false);
+  });
+});
+
+describe('Acyclic Shadows plugin — win-check rejects the traps', () => {
+  it('a closed loop whose shadow is itself a cycle is NOT solved (unit square)', () => {
+    // a 1×1 square in the z=0 plane: a genuine closed loop, but its XY shadow is a 4-cycle
+    const square = loopEdges([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]);
+    expect(plugin._isSingleLoop(square)).toBe(true);
+    const a = plugin._analyze(square);
+    expect(a.acyclic).toBeLessThan(3); // the XY shadow has a cycle
+    expect(plugin.isSolved({ n: 3, edges: square }).solved).toBe(false);
+  });
+
+  it('two disjoint loops are not a single closed loop', () => {
+    const sq1 = loopEdges([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]);
+    const sq2 = loopEdges([[0, 0, 2], [1, 0, 2], [1, 1, 2], [0, 1, 2]]);
+    expect(plugin._isSingleLoop([...sq1, ...sq2])).toBe(false);
+  });
+
+  it('a path with a branch point (degree 3) is not a single closed loop', () => {
+    const square = loopEdges([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]);
+    const spur = ekey([0, 0, 0], [0, 0, 1]); // makes vertex 0,0,0 degree 3
+    expect(plugin._isSingleLoop([...square, spur])).toBe(false);
+  });
+
+  it('an open path (not closed) is not solved', () => {
+    const open = [ekey([0, 0, 0], [1, 0, 0]), ekey([1, 0, 0], [1, 1, 0])];
+    expect(plugin._isSingleLoop(open)).toBe(false);
+    expect(plugin.isSolved({ n: 3, edges: open }).solved).toBe(false);
+  });
+});
+
+describe('Acyclic Shadows plugin — moves are pure', () => {
+  it('toggle adds then removes an edge without mutating the input', () => {
+    const s0: State = { n: 3, edges: [] };
+    const key = plugin._latticeEdges(3)[0];
+    const s1 = plugin.applyMove(s0, { type: 'toggle', key });
+    expect(s0.edges).toHaveLength(0); // input untouched
+    expect(s1.edges).toEqual([key]);
+    const s2 = plugin.applyMove(s1, { type: 'toggle', key });
+    expect(s2.edges).toHaveLength(0);
+  });
+
+  it("'solution' loads the Rickard loop and 'clear' empties it", () => {
+    const loaded = plugin.applyMove({ n: 3, edges: [] }, { type: 'solution' });
+    expect(loaded.edges).toHaveLength(24);
+    expect(plugin.isSolved(loaded).solved).toBe(true);
+    const cleared = plugin.applyMove(loaded, { type: 'clear' });
+    expect(cleared.edges).toHaveLength(0);
+  });
+
+  it("'set' replaces the whole edge set without aliasing the input (drives Undo)", () => {
+    const some = plugin._latticeEdges(3).slice(0, 3);
+    const s = plugin.applyMove({ n: 3, edges: [] }, { type: 'set', edges: some });
+    expect(s.edges).toEqual(some);
+    some.push('mutated'); // prove applyMove copied the array
+    expect(s.edges).toHaveLength(3);
+  });
+
+  it('legalMoves enumerates every lattice edge as a toggle', () => {
+    const moves = plugin.legalMoves({ n: 3, edges: [] });
+    // 3 * n^2 * (n-1) unit edges for n=3 -> 54
+    expect(moves).toHaveLength(54);
+    expect(moves.every((m) => m.type === 'toggle' && typeof m.key === 'string')).toBe(true);
+  });
+});

--- a/src/__tests__/runtime/pluginSchema.test.ts
+++ b/src/__tests__/runtime/pluginSchema.test.ts
@@ -26,9 +26,9 @@ describe('engine discriminator backwards-compat', () => {
   );
 
   it('every non-plugin built-in resolves to the grid tier', () => {
-    for (const { slug, def } of allPuzzles) {
+    for (const { def } of allPuzzles) {
       const parsed = PuzzleDefinitionSchema.parse(def);
-      if (slug === 'rubiks-cube') continue;
+      if (parsed.engine === 'plugin') continue;
       expect(parsed.engine === undefined || parsed.engine === 'grid').toBe(true);
     }
   });

--- a/src/components/editor/PluginCodeEditor.tsx
+++ b/src/components/editor/PluginCodeEditor.tsx
@@ -5,6 +5,7 @@ import './monacoSetup'; // side effect: configures MonacoEnvironment + loader
 import { usePuzzleStore } from '../../store/puzzleStore';
 import type { PuzzleDefinition, PluginRenderKind } from '../../types/puzzle';
 import { RUBIKS_CUBE_PLUGIN_SOURCE } from '../../runtime/plugin/examples/rubiksCubePlugin';
+import { ACYCLIC_SHADOWS_PLUGIN_SOURCE } from '../../runtime/plugin/examples/acyclicShadowsPlugin';
 import { Button } from '../ui/shadcn/button';
 import { Play } from 'lucide-react';
 import {
@@ -84,6 +85,7 @@ interface Template { label: string; renderKind: PluginRenderKind; source: string
 const TEMPLATES: Template[] = [
   { label: 'Toggle Grid (DOM)', renderKind: 'dom', source: STARTER_DOM },
   { label: "Rubik's Cube (WebGL)", renderKind: 'webgl', source: RUBIKS_CUBE_PLUGIN_SOURCE },
+  { label: 'Acyclic Shadows (WebGL)', renderKind: 'webgl', source: ACYCLIC_SHADOWS_PLUGIN_SOURCE },
 ];
 
 /** Best-effort read of meta.title from the module source for the initial

--- a/src/config/puzzleCategories.ts
+++ b/src/config/puzzleCategories.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_PUZZLE, FIT_ALL_PUZZLE, BLANK_PUZZLE, SLIDER_PUZZLE, GRID_PUZZLE, BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, COLORFUL_COVERAGE_PUZZLE } from '../types/puzzle';
 import { KLOTSKI_RED_DONKEY, KLOTSKI_CROSSWAY, PEN_CHALLENGE_PUZZLE, NONOGRAM_PUZZLE, NONOGRAM_PUZZLE_2 } from '../types/puzzle';
-import { RUBIKS_CUBE_PUZZLE } from '../data/puzzles';
+import { RUBIKS_CUBE_PUZZLE, ACYCLIC_SHADOWS_PUZZLE } from '../data/puzzles';
 import type { LucideIcon } from 'lucide-react';
 import { Grid3x3, LayoutGrid, Move, Binary, Lightbulb, Brain, Box } from 'lucide-react';
 
@@ -80,6 +80,7 @@ export const PUZZLE_CATEGORIES: PuzzleCategory[] = [
     icon: Box,
     puzzles: [
       { id: 'rubiks-cube', label: "Rubik's Cube", puzzle: RUBIKS_CUBE_PUZZLE, is3D: true },
+      { id: 'acyclic-shadows', label: 'Acyclic Shadows', puzzle: ACYCLIC_SHADOWS_PUZZLE, is3D: true },
     ],
   },
 ];

--- a/src/data/puzzles/acyclicShadows.ts
+++ b/src/data/puzzles/acyclicShadows.ts
@@ -1,0 +1,39 @@
+import type { PuzzleDefinition } from '../../types/puzzle';
+import { ACYCLIC_SHADOWS_PLUGIN_SOURCE } from '../../runtime/plugin/examples/acyclicShadowsPlugin';
+
+/**
+ * Acyclic Shadows — the Lenstra / Oskar's-maze problem as an `engine: 'plugin'`
+ * puzzle. Lay a single closed loop of bricks on a 3×3×3 lattice whose three
+ * orthogonal shadows are all trees (no cycle in any projection). Solvable —
+ * "Show solution" reveals Rickard's minimal length-24 loop.
+ *
+ * Like the Rubik's cube, the board/inventory/validation_rules below are harmless
+ * minimal stubs the plugin engine ignores; all real behaviour lives in the
+ * author module referenced by `plugin.module`, run inside a sandboxed iframe.
+ */
+export const ACYCLIC_SHADOWS_PUZZLE: PuzzleDefinition = {
+  title: 'Acyclic Shadows',
+  description:
+    "A closed loop in 3D whose three orthogonal shadows must each be a tree — no cycle in any projection. This is Hendrik Lenstra's 1994 question about Oskar's maze cube, built as a plugin puzzle: the editor is just the engine, running the author's own state, rendering and win check. Click lattice edges to build the loop; 'Show solution' reveals John Rickard's minimal length-24 answer.",
+  engine: 'plugin',
+  plugin: {
+    module: ACYCLIC_SHADOWS_PLUGIN_SOURCE,
+    renderKind: 'webgl',
+    seed: 1,
+    // n = lattice vertices per axis; start = 'empty' (solve from scratch) | 'rickard'.
+    params: { n: 3, start: 'empty' },
+    apiVersion: 1,
+  },
+  viewMode: '3D',
+  board: {
+    dimensions: { width: 1, height: 1, depth: 1 },
+    initial_state: [],
+  },
+  inventory: [],
+  validation_rules: [],
+  metadata: {
+    author: 'Engine demo',
+    difficulty: 'hard',
+    tags: ['plugin', 'topology', 'mechanical', 'oskar-maze'],
+  },
+};

--- a/src/data/puzzles/index.ts
+++ b/src/data/puzzles/index.ts
@@ -12,3 +12,4 @@ export { BLANK_PUZZLE, FIT_ALL_PUZZLE } from './templates';
 
 // Plugin puzzles (author-coded, run in a sandbox)
 export { RUBIKS_CUBE_PUZZLE } from './rubiks';
+export { ACYCLIC_SHADOWS_PUZZLE } from './acyclicShadows';

--- a/src/runtime/plugin/PluginRenderer.tsx
+++ b/src/runtime/plugin/PluginRenderer.tsx
@@ -3,6 +3,7 @@ import { LoaderCircle } from 'lucide-react';
 import { PluginHostFrame, type PluginFrameState, type LibSpec } from './PluginHostFrame';
 import type { PuzzlePluginMeta } from './contract';
 import type { PuzzleDefinition } from '../../types/puzzle';
+import { useUserStore } from '../../store/userStore';
 
 /**
  * PluginRenderer — the host-side React surface for a `engine: 'plugin'` puzzle.
@@ -35,6 +36,9 @@ interface PluginRendererProps {
 export function PluginRenderer({ puzzle, resetSignal = 0, onState, onComplete, onMeta, onError }: PluginRendererProps) {
   const plugin = puzzle.plugin;
   const needsThree = plugin?.renderKind === 'webgl';
+  // Passed into the sandbox so plugins can gate admin-only UI (e.g. "Show
+  // solution"). The sandbox can't see auth itself, so the host injects it.
+  const isAdmin = useUserStore((s) => s.profile?.role === 'admin');
 
   const [progress, setProgress] = useState(0);
   const [solved, setSolved] = useState(false);
@@ -114,7 +118,7 @@ export function PluginRenderer({ puzzle, resetSignal = 0, onState, onComplete, o
         <PluginHostFrame
           source={plugin.module}
           seed={plugin.seed ?? 0}
-          params={plugin.params}
+          params={{ ...plugin.params, isAdmin }}
           libs={libs}
           resetSignal={resetSignal}
           onReady={(meta, st) => {

--- a/src/runtime/plugin/contract.ts
+++ b/src/runtime/plugin/contract.ts
@@ -49,6 +49,9 @@ export interface PluginRenderApi<S, M> {
   getState(): S;
   /** Submit a move; the host applies it via `applyMove` and re-renders. */
   emitMove(move: M): void;
+  /** Render-time config from the host: the puzzle's `plugin.params` plus host
+   *  injections such as `isAdmin`. Not part of game state — for gating UI. */
+  params?: Record<string, unknown>;
   helpers: PluginHelpers;
 }
 

--- a/src/runtime/plugin/examples/acyclicShadowsPlugin.ts
+++ b/src/runtime/plugin/examples/acyclicShadowsPlugin.ts
@@ -1,0 +1,581 @@
+/**
+ * Acyclic Shadows — an `engine: 'plugin'` puzzle that the grid model cannot
+ * express, and a showcase for why Tier 2 exists: the entire puzzle hinges on a
+ * non-trivial COMPUTATIONAL win-check (graph acyclicity of three orthogonal
+ * projections) that lives wholly in author code.
+ *
+ * THE PUZZLE (the Lenstra / Oskar's-maze problem, 1994). Lay a single simple
+ * CLOSED loop of unit bricks on a 3D integer lattice so that its three
+ * orthogonal shadows — the projections onto the XY, XZ and YZ planes — each
+ * contain NO cycle (each shadow is a tree). This is exactly what Hendrik
+ * Lenstra asked of Oskar van Deventer's maze cube: a closed curve whose three
+ * shadows are all trees. It is solvable — John R. Rickard found the minimal
+ * length-24 solution (popularised as Adam P. Goucher's knotted "Treefoil") —
+ * and we embed Rickard's curve as the "Show solution" reveal.
+ *
+ * THE ONE MATH NUANCE baked into the win-check: shadows must be TREES (acyclic,
+ * branch points allowed), NOT simple PATHS. "No cycle in any shadow" is
+ * achievable; demanding each shadow be a non-branching path is provably
+ * IMPOSSIBLE for a closed loop (Bose, De Carufel, Dobbins, Kim, Viglietta —
+ * "The Shadows of a Cycle Cannot All Be Paths", CCCG 2015). So isSolved tests
+ * acyclicity (a forest) and never forbids branch points.
+ *
+ * STATE: { n, edges } — n vertices per lattice axis (coords 0..n-1); edges is a
+ *   SET of canonical unit-edge keys "x,y,z|x,y,z" (smaller endpoint first).
+ * MOVES: { type:'toggle', key } add/remove an edge; 'clear'; 'solution'.
+ * WIN: a single simple closed loop AND all three shadows acyclic.
+ * RENDER: Three.js — the loop as bricks, the three live shadows on the back
+ *   walls, cyclic shadow edges painted red. Drag to orbit; click an edge to
+ *   toggle (raycast against fat invisible pick proxies).
+ *
+ * As with the Rubik's example, the value below is the self-contained ES module
+ * SOURCE that runs inside the sandbox; the pure logic is side-effect free so it
+ * is unit-tested directly (see src/__tests__/runtime/acyclicShadowsPlugin.test.ts)
+ * and a later tier can run it authoritatively in a Web Worker unchanged.
+ */
+export const ACYCLIC_SHADOWS_PLUGIN_SOURCE = String.raw`
+const ACYCLIC = (function () {
+  "use strict";
+
+  // ---------- lattice + edge helpers (pure) ----------
+  function vkey(p) { return p[0] + "," + p[1] + "," + p[2]; }
+  function less3(a, b) {
+    if (a[0] !== b[0]) return a[0] < b[0];
+    if (a[1] !== b[1]) return a[1] < b[1];
+    return a[2] < b[2];
+  }
+  function ekey(a, b) {
+    return less3(a, b) ? vkey(a) + "|" + vkey(b) : vkey(b) + "|" + vkey(a);
+  }
+  function parseEdge(k) {
+    var parts = k.split("|");
+    return [parts[0].split(",").map(Number), parts[1].split(",").map(Number)];
+  }
+
+  // Every unit edge of an n-per-axis lattice (coords 0..n-1). Deterministic order.
+  function latticeEdges(n) {
+    var out = [];
+    for (var x = 0; x < n; x++) for (var y = 0; y < n; y++) for (var z = 0; z < n; z++) {
+      if (x + 1 < n) out.push(ekey([x, y, z], [x + 1, y, z]));
+      if (y + 1 < n) out.push(ekey([x, y, z], [x, y + 1, z]));
+      if (z + 1 < n) out.push(ekey([x, y, z], [x, y, z + 1]));
+    }
+    return out;
+  }
+
+  // ---------- union-find (returns false from union when the edge closes a cycle) ----------
+  function UF() {
+    var parent = {};
+    function find(a) {
+      if (parent[a] === undefined) { parent[a] = a; return a; }
+      var root = a;
+      while (parent[root] !== root) root = parent[root];
+      while (parent[a] !== root) { var nx = parent[a]; parent[a] = root; a = nx; }
+      return root;
+    }
+    return {
+      find: find,
+      union: function (a, b) {
+        var ra = find(a), rb = find(b);
+        if (ra === rb) return false;
+        parent[ra] = rb; return true;
+      }
+    };
+  }
+
+  // ---------- single simple closed loop test ----------
+  // A connected, 2-regular simple graph is exactly one cycle (and then V === E).
+  function isSingleLoop(edges) {
+    if (edges.length < 4) return false;
+    var deg = {}, uf = UF(), verts = {};
+    for (var i = 0; i < edges.length; i++) {
+      var e = parseEdge(edges[i]);
+      var ka = vkey(e[0]), kb = vkey(e[1]);
+      deg[ka] = (deg[ka] || 0) + 1;
+      deg[kb] = (deg[kb] || 0) + 1;
+      verts[ka] = 1; verts[kb] = 1;
+      uf.union(ka, kb);
+    }
+    var keys = Object.keys(verts);
+    if (keys.length !== edges.length) return false;
+    for (var j = 0; j < keys.length; j++) if (deg[keys[j]] !== 2) return false;
+    var root = uf.find(keys[0]);
+    for (var m = 1; m < keys.length; m++) if (uf.find(keys[m]) !== root) return false;
+    return true;
+  }
+
+  // ---------- shadow (orthogonal projection) analysis ----------
+  // drop: 0 -> YZ plane, 1 -> XZ plane, 2 -> XY plane.
+  function keep2(p, drop) {
+    if (drop === 0) return [p[1], p[2]];
+    if (drop === 1) return [p[0], p[2]];
+    return [p[0], p[1]];
+  }
+  function k2(p) { return p[0] + "," + p[1]; }
+  function less2(a, b) { return a[0] !== b[0] ? a[0] < b[0] : a[1] < b[1]; }
+  function e2key(a, b) { return less2(a, b) ? k2(a) + "|" + k2(b) : k2(b) + "|" + k2(a); }
+
+  // The four correctness fixes that a naive cut gets wrong are marked inline.
+  function analyzeShadow(edges, drop) {
+    var seen = {}, list = [];
+    for (var i = 0; i < edges.length; i++) {
+      var e = parseEdge(edges[i]);
+      var a2 = keep2(e[0], drop), b2 = keep2(e[1], drop);
+      if (a2[0] === b2[0] && a2[1] === b2[1]) continue;   // FIX 1: edge parallel to dropped axis -> a POINT, skip
+      var key = e2key(a2, b2);                            // FIX 2: EXACT unit-edge dedup (never collinear-merge)
+      if (seen[key]) continue;
+      seen[key] = 1;
+      list.push({ key: key, a: a2, b: b2, closing: false });
+    }
+    list.sort(function (p, q) { return p.key < q.key ? -1 : (p.key > q.key ? 1 : 0); });
+    var uf = UF(), closing = {};
+    for (var j = 0; j < list.length; j++) {
+      var it = list[j];                                   // FIX 3: shadow vertices keyed by 2D coords -> coincident projections unify
+      if (!uf.union(k2(it.a), k2(it.b))) { it.closing = true; closing[it.key] = 1; } // FIX 4: union-find forest test
+    }
+    return { acyclic: Object.keys(closing).length === 0, edges2: list, closing: closing };
+  }
+
+  function analyze(edges) {
+    var sh = [analyzeShadow(edges, 0), analyzeShadow(edges, 1), analyzeShadow(edges, 2)];
+    return {
+      loop: isSingleLoop(edges),
+      shadows: sh,
+      acyclic: (sh[0].acyclic ? 1 : 0) + (sh[1].acyclic ? 1 : 0) + (sh[2].acyclic ? 1 : 0)
+    };
+  }
+
+  var PLANE_NAME = ["YZ", "XZ", "XY"];
+
+  function isSolved(state) {
+    var edges = (state && state.edges) || [];
+    if (edges.length === 0) {
+      return { solved: false, progress: 0, message: "Lay a closed loop of bricks on the lattice." };
+    }
+    var a = analyze(edges);
+    if (!a.loop) {
+      var deg = {}, used = {};
+      for (var i = 0; i < edges.length; i++) {
+        var e = parseEdge(edges[i]), ka = vkey(e[0]), kb = vkey(e[1]);
+        deg[ka] = (deg[ka] || 0) + 1; deg[kb] = (deg[kb] || 0) + 1; used[ka] = 1; used[kb] = 1;
+      }
+      var uk = Object.keys(used), bad = 0;
+      for (var j = 0; j < uk.length; j++) if (deg[uk[j]] !== 2) bad++;
+      var loopiness = uk.length ? (1 - bad / uk.length) : 0;
+      return {
+        solved: false,
+        progress: 0.35 * loopiness,
+        message: "Not one closed loop yet — " + bad + " open end" + (bad === 1 ? "" : "s") + " or junction" + (bad === 1 ? "" : "s") + " to fix."
+      };
+    }
+    if (a.acyclic === 3) {
+      return { solved: true, progress: 1, message: "Solved — a closed loop whose three shadows are all trees!" };
+    }
+    var cyc = [];
+    for (var s = 0; s < 3; s++) if (!a.shadows[s].acyclic) cyc.push(PLANE_NAME[s]);
+    return {
+      solved: false,
+      progress: 0.4 + 0.6 * (a.acyclic / 3),
+      message: "Closed loop! But the " + cyc.join(" & ") + " shadow" + (cyc.length === 1 ? "" : "s") + " still contain a cycle (red)."
+    };
+  }
+
+  // ---------- embedded minimal Rickard solution (length 24, coords 0..2) ----------
+  var RICKARD_VERTS = [
+    [2,0,2],[2,1,2],[1,1,2],[0,1,2],[0,0,2],[0,0,1],[0,1,1],[0,2,1],[0,2,2],[1,2,2],[1,2,1],[1,2,0],
+    [0,2,0],[0,1,0],[1,1,0],[2,1,0],[2,2,0],[2,2,1],[2,1,1],[2,0,1],[2,0,0],[1,0,0],[1,0,1],[1,0,2]
+  ];
+  function rickardEdges() {
+    var out = [];
+    for (var i = 0; i < RICKARD_VERTS.length; i++) {
+      out.push(ekey(RICKARD_VERTS[i], RICKARD_VERTS[(i + 1) % RICKARD_VERTS.length]));
+    }
+    return out;
+  }
+
+  // ---------- state + moves (pure) ----------
+  function initialState(ctx) {
+    var params = (ctx && ctx.params) || {};
+    var n = typeof params.n === "number" ? params.n : 3;
+    var edges = params.start === "rickard" ? rickardEdges() : [];
+    return { n: n, edges: edges };
+  }
+
+  function applyMove(state, move) {
+    var n = state.n, edges = state.edges.slice();
+    if (!move) return { n: n, edges: edges };
+    if (move.type === "clear") return { n: n, edges: [] };
+    if (move.type === "solution") return { n: n, edges: rickardEdges() };
+    if (move.type === "set" && Array.isArray(move.edges)) return { n: n, edges: move.edges.slice() };
+    if (move.type === "toggle" && move.key) {
+      var idx = edges.indexOf(move.key);
+      if (idx >= 0) edges.splice(idx, 1); else edges.push(move.key);
+      return { n: n, edges: edges };
+    }
+    return { n: n, edges: edges };
+  }
+
+  function legalMoves(state) {
+    return latticeEdges(state.n).map(function (k) { return { type: "toggle", key: k }; });
+  }
+
+  // ---------- render (WebGL via self.THREE; only runs inside the sandbox) ----------
+  function mount(root, api) {
+    var THREE = self.THREE;
+    if (!THREE) {
+      root.textContent = "Three.js was not provided to the sandbox.";
+      return { update: function () {}, dispose: function () {} };
+    }
+
+    root.style.position = "relative";
+    root.textContent = "";
+
+    var state0 = api.getState();
+    var n = (state0 && state0.n) || 3;
+
+    // Undo history: a stack of previous edge-sets. Each user-driven change pushes
+    // where we came from; Undo pops it and emits a 'set' move to restore it.
+    var prevEdges = ((state0 && state0.edges) || []).slice();
+    var history = [];
+    var suppressHistory = false;
+    function sameEdges(a, b) {
+      if (a.length !== b.length) return false;
+      var m = {}; for (var i = 0; i < a.length; i++) m[a[i]] = 1;
+      for (var j = 0; j < b.length; j++) if (!m[b[j]]) return false;
+      return true;
+    }
+
+    var c = (n - 1) / 2;          // center offset (lattice -> world)
+    var WALL = c + 1.4;           // distance of each shadow wall from center
+    var SW = WALL - 0.02;         // shadow drawn just in front of its wall (no z-fight)
+
+    var scene = new THREE.Scene();
+    var camera = new THREE.PerspectiveCamera(40, 1, 0.1, 200);
+    var R = n * 2.2 + 4;
+    camera.position.set(R * 0.64, R * 0.52, R * 0.78);
+    camera.lookAt(0, 0, 0);
+
+    var renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(self.devicePixelRatio || 1, 2));
+    renderer.domElement.style.display = "block";
+    renderer.domElement.style.cursor = "grab";
+    root.appendChild(renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.85));
+    var keyL = new THREE.DirectionalLight(0xffffff, 0.8); keyL.position.set(6, 9, 7); scene.add(keyL);
+    var fillL = new THREE.DirectionalLight(0xffffff, 0.3); fillL.position.set(-6, -4, -5); scene.add(fillL);
+
+    // Trackball orbit: drag in ANY direction spins the cube that way. The rotation
+    // is composed as a quaternion about the camera's screen axes, so there's no
+    // gimbal twist and no limit — you can roll it all the way around to any side.
+    var ROT_SENS = 0.01;                            // rotation speed (radians per pixel dragged)
+    var INIT_CAM = camera.position.clone();         // default zoom/position
+    var world = new THREE.Group();
+    world.rotation.set(0.34, -0.6, 0);              // pleasant default 3/4 view
+    scene.add(world);
+    var INIT_QUAT = world.quaternion.clone();       // restored by "Reset view"
+
+    function w(p) { return [p[0] - c, p[1] - c, p[2] - c]; }
+
+    // shadow walls (the far corner of a "room") — toggled by the "Hide walls" button
+    var walls = [];
+    function addWall(drop) {
+      var size = (n - 1) + 0.6;
+      var mesh = new THREE.Mesh(
+        new THREE.PlaneGeometry(size, size),
+        new THREE.MeshBasicMaterial({ color: 0x0c0e13, transparent: true, opacity: 0.55, side: THREE.DoubleSide })
+      );
+      if (drop === 2) mesh.position.set(0, 0, -WALL);
+      else if (drop === 1) { mesh.position.set(0, -WALL, 0); mesh.rotation.x = Math.PI / 2; }
+      else { mesh.position.set(-WALL, 0, 0); mesh.rotation.y = Math.PI / 2; }
+      world.add(mesh); walls.push(mesh);
+    }
+    addWall(0); addWall(1); addWall(2);
+
+    // lattice vertex dots (faint)
+    var dotGeo = new THREE.SphereGeometry(0.05, 8, 8);
+    var dotMat = new THREE.MeshBasicMaterial({ color: 0x39404e });
+    for (var dx = 0; dx < n; dx++) for (var dy = 0; dy < n; dy++) for (var dz = 0; dz < n; dz++) {
+      var dot = new THREE.Mesh(dotGeo, dotMat);
+      var dp = w([dx, dy, dz]); dot.position.set(dp[0], dp[1], dp[2]); world.add(dot);
+    }
+
+    // candidate edges: shared geometry per axis; faint guide + brick (on when active) + invisible pick proxy
+    var ACTIVE = 0xffb000, ACTIVE_BAD = 0xff3b3b, GUIDE_COL = 0x2b3340;
+    function boxByAxis(ax, lng, thin) {
+      return new THREE.BoxGeometry(ax === 0 ? lng : thin, ax === 1 ? lng : thin, ax === 2 ? lng : thin);
+    }
+    var guideGeo = [boxByAxis(0, 1, 0.04), boxByAxis(1, 1, 0.04), boxByAxis(2, 1, 0.04)];
+    var brickGeo = [boxByAxis(0, 1, 0.20), boxByAxis(1, 1, 0.20), boxByAxis(2, 1, 0.20)];
+    var proxyGeo = [boxByAxis(0, 1, 0.42), boxByAxis(1, 1, 0.42), boxByAxis(2, 1, 0.42)];
+    var guideMat = new THREE.MeshBasicMaterial({ color: GUIDE_COL });
+    var proxyMat = new THREE.MeshBasicMaterial({ visible: false });
+
+    var edgeObjs = {};
+    var proxies = [];
+    var edgeKeys = latticeEdges(n);
+    for (var ei = 0; ei < edgeKeys.length; ei++) {
+      var ek = edgeKeys[ei];
+      var pe = parseEdge(ek);
+      var wa = w(pe[0]), wb = w(pe[1]);
+      var mid = [(wa[0] + wb[0]) / 2, (wa[1] + wb[1]) / 2, (wa[2] + wb[2]) / 2];
+      var ax = pe[0][0] !== pe[1][0] ? 0 : (pe[0][1] !== pe[1][1] ? 1 : 2);
+
+      var guide = new THREE.Mesh(guideGeo[ax], guideMat);
+      guide.position.set(mid[0], mid[1], mid[2]); world.add(guide);
+
+      var bmat = new THREE.MeshStandardMaterial({ color: ACTIVE, roughness: 0.42, metalness: 0.0 });
+      var brick = new THREE.Mesh(brickGeo[ax], bmat);
+      brick.position.set(mid[0], mid[1], mid[2]); brick.visible = false; world.add(brick);
+
+      var proxy = new THREE.Mesh(proxyGeo[ax], proxyMat);
+      proxy.position.set(mid[0], mid[1], mid[2]); proxy.userData.key = ek; world.add(proxy); proxies.push(proxy);
+
+      edgeObjs[ek] = { brick: brick, bmat: bmat };
+    }
+
+    // shadow line segments (rebuilt each update; tiny graphs, cheap)
+    var shadowGroup = new THREE.Group(); world.add(shadowGroup);
+    function clearShadow() {
+      for (var i = shadowGroup.children.length - 1; i >= 0; i--) {
+        var ch = shadowGroup.children[i];
+        shadowGroup.remove(ch);
+        if (ch.geometry) ch.geometry.dispose();
+        if (ch.material) ch.material.dispose();
+      }
+    }
+    function shadowWorld(p2, drop) {
+      if (drop === 2) return [p2[0] - c, p2[1] - c, -SW];
+      if (drop === 1) return [p2[0] - c, -SW, p2[1] - c];
+      return [-SW, p2[0] - c, p2[1] - c];
+    }
+    function buildShadow(shadow, drop) {
+      var greenPos = [], redPos = [];
+      for (var i = 0; i < shadow.edges2.length; i++) {
+        var it = shadow.edges2[i];
+        var A = shadowWorld(it.a, drop), B = shadowWorld(it.b, drop);
+        var arr = it.closing ? redPos : greenPos;
+        arr.push(A[0], A[1], A[2], B[0], B[1], B[2]);
+      }
+      function seg(pos, color) {
+        if (!pos.length) return;
+        var g = new THREE.BufferGeometry();
+        g.setAttribute("position", new THREE.Float32BufferAttribute(pos, 3));
+        shadowGroup.add(new THREE.LineSegments(g, new THREE.LineBasicMaterial({ color: color })));
+      }
+      seg(greenPos, shadow.acyclic ? 0x46d17a : 0x9aa6b2);
+      seg(redPos, 0xff3b3b);
+    }
+
+    var dirty = true;
+    function invalidate() { dirty = true; }
+
+    // ---- zoom: dolly the camera toward/away from the origin it looks at ----
+    var camMinDist = R * 0.45, camMaxDist = R * 3.0;
+    function zoomBy(factor) {
+      var d = camera.position.length();
+      var nd = Math.max(camMinDist, Math.min(camMaxDist, d * factor));
+      if (nd !== d) { camera.position.multiplyScalar(nd / d); invalidate(); }
+    }
+
+    // ---- reset the view (orbit + zoom) back to its default ----
+    function resetView() {
+      world.quaternion.copy(INIT_QUAT);
+      camera.position.copy(INIT_CAM);
+      camera.lookAt(0, 0, 0);
+      invalidate();
+    }
+
+    // DOM overlay: status line + buttons
+    var ui = document.createElement("div");
+    ui.style.cssText = "position:absolute;left:0;right:0;bottom:8px;display:flex;flex-direction:column;align-items:center;gap:6px;font-family:system-ui,sans-serif;pointer-events:none";
+    var status = document.createElement("div");
+    status.style.cssText = "max-width:92%;text-align:center;font-size:12px;font-weight:600;color:#e8e8ea;background:rgba(20,22,28,0.72);padding:5px 10px;border-radius:7px";
+    var bar = document.createElement("div");
+    bar.style.cssText = "display:flex;flex-wrap:wrap;justify-content:center;gap:6px;pointer-events:auto";
+    function mkBtn(label, fn) {
+      var b = document.createElement("button");
+      b.textContent = label;
+      b.style.cssText = "padding:6px 10px;font-size:12px;font-weight:600;color:#e8e8ea;background:#262a33;border:1px solid #3a3f4b;border-radius:6px;cursor:pointer";
+      b.onmouseenter = function () { b.style.background = "#30353f"; };
+      b.onmouseleave = function () { b.style.background = "#262a33"; };
+      b.onclick = fn; bar.appendChild(b); return b;
+    }
+    var undoBtn = mkBtn("Undo", function () {
+      if (!history.length) return;
+      suppressHistory = true;
+      api.emitMove({ type: "set", edges: history.pop() });
+    });
+    mkBtn("Clear", function () { api.emitMove({ type: "clear" }); });
+    // "Show solution" is admin-only. The host injects the current viewer's admin
+    // status as api.params.isAdmin (the sandbox can't read auth on its own).
+    if (api.params && api.params.isAdmin) {
+      mkBtn("Show solution", function () { api.emitMove({ type: "solution" }); });
+    }
+    mkBtn("Zoom in", function () { zoomBy(1 / 1.15); });
+    mkBtn("Zoom out", function () { zoomBy(1.15); });
+    mkBtn("Reset view", function () { resetView(); });
+    var wallsVisible = true;
+    var wallsBtn = mkBtn("Hide walls", function () {
+      wallsVisible = !wallsVisible;
+      for (var wi = 0; wi < walls.length; wi++) walls[wi].visible = wallsVisible;
+      shadowGroup.visible = wallsVisible;        // also hide/show the shadows drawn on the walls
+      wallsBtn.textContent = wallsVisible ? "Hide walls" : "Show walls";
+      invalidate();
+    });
+    ui.appendChild(status); ui.appendChild(bar);
+    root.appendChild(ui);
+
+    // orbit (drag) + pick (click). A small movement threshold separates the two.
+    var dragging = false, moved = 0, lx = 0, ly = 0, pinch = 0;
+    var raycaster = new THREE.Raycaster(), ndc = new THREE.Vector2();
+    function pt(e) { return e.touches && e.touches[0] ? e.touches[0] : e; }
+    function touchDist(e) {
+      var a = e.touches[0], b = e.touches[1];
+      var dx = a.clientX - b.clientX, dy = a.clientY - b.clientY;
+      return Math.sqrt(dx * dx + dy * dy);
+    }
+    function down(e) {
+      if (e.touches && e.touches.length >= 2) { pinch = touchDist(e); dragging = false; return; }
+      dragging = true; moved = 0; var p = pt(e); lx = p.clientX; ly = p.clientY; renderer.domElement.style.cursor = "grabbing";
+    }
+    function move(e) {
+      if (e.touches && e.touches.length >= 2) {            // pinch-to-zoom
+        var nd = touchDist(e);
+        if (pinch > 0 && nd > 0) zoomBy(pinch / nd);       // fingers spread (nd>pinch) -> factor<1 -> zoom in
+        pinch = nd; invalidate(); return;
+      }
+      if (!dragging) return;
+      var p = pt(e);
+      var dx = p.clientX - lx, dy = p.clientY - ly;
+      moved += Math.abs(dx) + Math.abs(dy);
+      // rotate about the camera's own right/up axes (expressed in world space) so the
+      // cube always follows the drag, from any current orientation.
+      var right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
+      var up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+      var q = new THREE.Quaternion().setFromAxisAngle(up, dx * ROT_SENS);
+      q.multiply(new THREE.Quaternion().setFromAxisAngle(right, dy * ROT_SENS));
+      world.quaternion.premultiply(q);
+      lx = p.clientX; ly = p.clientY; invalidate();
+    }
+    function up(e) {
+      if (dragging && moved < 6) pick(e);
+      dragging = false; pinch = 0; renderer.domElement.style.cursor = "grab";
+    }
+    function onWheel(e) { e.preventDefault(); zoomBy(e.deltaY > 0 ? 1.1 : 0.9); }
+    function pick(e) {
+      var p = pt(e), rect = renderer.domElement.getBoundingClientRect();
+      ndc.x = ((p.clientX - rect.left) / rect.width) * 2 - 1;
+      ndc.y = -((p.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(ndc, camera);
+      var hits = raycaster.intersectObjects(proxies, false);
+      if (hits.length) api.emitMove({ type: "toggle", key: hits[0].object.userData.key });
+    }
+    renderer.domElement.addEventListener("mousedown", down);
+    self.addEventListener("mousemove", move);
+    self.addEventListener("mouseup", up);
+    renderer.domElement.addEventListener("touchstart", down, { passive: true });
+    self.addEventListener("touchmove", move, { passive: true });
+    self.addEventListener("touchend", up);
+    renderer.domElement.addEventListener("wheel", onWheel, { passive: false });
+
+    function update(stateNow) {
+      var edges = (stateNow && stateNow.edges) || [];
+
+      // history bookkeeping: record the prior edge-set unless this update IS an undo
+      if (suppressHistory) { suppressHistory = false; }
+      else if (!sameEdges(edges, prevEdges)) { history.push(prevEdges); }
+      prevEdges = edges.slice();
+      undoBtn.style.opacity = history.length ? "1" : "0.45";
+
+      var eset = {}; for (var i = 0; i < edges.length; i++) eset[edges[i]] = 1;
+      var a = analyze(edges);
+
+      // 3D edges that close a cycle in some shadow -> paint red
+      var cyc3d = {};
+      for (var s = 0; s < 3; s++) {
+        var closing = a.shadows[s].closing;
+        for (var k = 0; k < edges.length; k++) {
+          var pe2 = parseEdge(edges[k]);
+          var u2 = keep2(pe2[0], s), v2 = keep2(pe2[1], s);
+          if (u2[0] === v2[0] && u2[1] === v2[1]) continue;
+          if (closing[e2key(u2, v2)]) cyc3d[edges[k]] = 1;
+        }
+      }
+
+      for (var key in edgeObjs) {
+        if (!Object.prototype.hasOwnProperty.call(edgeObjs, key)) continue;
+        var o = edgeObjs[key], on = !!eset[key];
+        o.brick.visible = on;
+        if (on) o.bmat.color.set(cyc3d[key] ? ACTIVE_BAD : ACTIVE);
+      }
+
+      clearShadow();
+      buildShadow(a.shadows[0], 0); buildShadow(a.shadows[1], 1); buildShadow(a.shadows[2], 2);
+
+      var verdict = isSolved(stateNow);
+      status.textContent = verdict.message;
+      status.style.color = verdict.solved ? "#46d17a" : "#e8e8ea";
+      invalidate();
+    }
+
+    var raf = 0;
+    function resize() {
+      var wpx = root.clientWidth || 420, hpx = root.clientHeight || 420;
+      renderer.setSize(wpx, hpx, false);
+      camera.aspect = wpx / hpx; camera.updateProjectionMatrix(); invalidate();
+    }
+    function loop() { raf = self.requestAnimationFrame(loop); if (dirty) { dirty = false; renderer.render(scene, camera); } }
+    var ro = (typeof ResizeObserver !== "undefined") ? new ResizeObserver(resize) : null;
+    if (ro) ro.observe(root); else self.addEventListener("resize", resize);
+    resize();
+    update(state0);
+    loop();
+
+    return {
+      update: update,
+      resize: resize,
+      dispose: function () {
+        self.cancelAnimationFrame(raf);
+        self.removeEventListener("mousemove", move);
+        self.removeEventListener("mouseup", up);
+        self.removeEventListener("touchmove", move);
+        self.removeEventListener("touchend", up);
+        renderer.domElement.removeEventListener("wheel", onWheel);
+        if (ro) ro.disconnect();
+        clearShadow();
+        world.traverse(function (obj) {
+          if (obj.geometry) obj.geometry.dispose();
+          if (obj.material) {
+            if (Array.isArray(obj.material)) obj.material.forEach(function (m) { m.dispose(); });
+            else obj.material.dispose();
+          }
+        });
+        renderer.dispose();
+        root.textContent = "";
+      }
+    };
+  }
+
+  return {
+    meta: {
+      title: "Acyclic Shadows",
+      instructions: "Click lattice edges to lay one closed loop of bricks. You win when the loop's three shadows (on the back walls) are all trees — no cycle in any shadow. Drag to orbit; 'Show solution' reveals Rickard's minimal loop.",
+      supportsUndo: true,
+      rngSeedable: false
+    },
+    initialState: initialState,
+    applyMove: applyMove,
+    legalMoves: legalMoves,
+    isSolved: isSolved,
+    render: { mount: mount },
+    // exposed for unit tests (host ignores extra keys)
+    _rickardEdges: rickardEdges,
+    _analyze: analyze,
+    _isSingleLoop: isSingleLoop,
+    _latticeEdges: latticeEdges
+  };
+})();
+
+export default ACYCLIC;
+`;


### PR DESCRIPTION
## Summary

Adds a new `engine: 'plugin'` puzzle — the Lenstra / Oskar's-maze **"Treefoil"** problem: build a single closed loop on a 3D lattice whose three orthogonal projections (shadows) are all **trees** (no cycle in any projection). The win check is pure graph acyclicity, and the puzzle embeds John Rickard's minimal length-24 solution for "Show solution".

## What's included

- **Plugin** (`src/runtime/plugin/examples/acyclicShadowsPlugin.ts`)
  - Pure logic: single-closed-loop test (degree-2 + one component) and a per-projection union-find **forest** test for the three shadows.
  - WebGL render: lattice + bricks, three live shadow walls, cyclic shadow edges painted red; click an edge (raycast) to toggle.
  - Controls: **Undo** (edge-set history via a `set` move), **wheel/pinch/button zoom**, **Reset view**, **Hide walls** (also hides the shadows drawn on them), **trackball rotation** (quaternion about the camera axes — no gimbal, no clamp).
  - **"Show solution" is admin-only.**
- **Engine change**: expose host params to `render.mount` via `api.params` (`contract.ts` + `public/plugin-sandbox.html`); `PluginRenderer` injects `isAdmin` (`profile.role === 'admin'`) into those params so plugins can gate admin-only UI. The sandbox stays auth-isolated.
- **Registration**: built-in `acyclic-shadows` (`puzzleCategories` + `data/puzzles`) and a new Plugin (Code) editor template.

## Testing

- `728` tests pass (12 new), `tsc -b` + `eslint` clean, production build OK.
- Verified in-browser: solved→win popup fires; Undo/zoom/reset/hide-walls/trackball all work; signed-out viewer correctly does **not** see "Show solution".

## Reviewer / deploy notes

- ⚠️ The admin gating needs a **real deploy** — it touches host files (`PluginRenderer.tsx`, `public/plugin-sandbox.html`), so it won't take effect via an in-app publish. Until deployed, `api.params.isAdmin` is undefined and the button hides for everyone.
- ⚠️ The "Show solution" gate is **cosmetic / client-side**: the solution coordinates and the `solution` move still ship in the (downloadable) plugin source, and `isAdmin` is client-provided. It hides the button for normal players but is not a security boundary.
