### PR TITLE
Mobile: dedicated layouts + touch-solvable puzzles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Virtual Lego Puzzle Editor</title>
     <meta name="description" content="Create, solve, and share virtual Lego brick puzzles. A community-driven puzzle platform with 3D and 2D editors." />
     <meta property="og:type" content="website" />

--- a/public/plugin-sandbox.html
+++ b/public/plugin-sandbox.html
@@ -19,8 +19,12 @@
 -->
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' blob:; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'; base-uri 'none'; form-action 'none';">
 <style>
-  html, body { margin: 0; height: 100%; background: transparent; overflow: hidden; }
-  #root { width: 100%; height: 100%; }
+  /* touch-action:none + overscroll-behavior:none stop one-finger orbit drags and
+     two-finger pinches from scrolling the page or triggering native zoom — even
+     though the plugins use passive touch listeners. canvas inherits it. */
+  html, body { margin: 0; height: 100%; background: transparent; overflow: hidden; touch-action: none; overscroll-behavior: none; }
+  #root { width: 100%; height: 100%; touch-action: none; }
+  canvas { touch-action: none; }
   * { box-sizing: border-box; }
 </style>
 </head>

--- a/public/plugin-sandbox.html
+++ b/public/plugin-sandbox.html
@@ -24,7 +24,12 @@
      though the plugins use passive touch listeners. canvas inherits it. */
   html, body { margin: 0; height: 100%; background: transparent; overflow: hidden; touch-action: none; overscroll-behavior: none; }
   #root { width: 100%; height: 100%; touch-action: none; }
-  canvas { touch-action: none; }
+  /* Force the plugin's canvas to fill its container regardless of how the
+     module sizes it. Plugins call renderer.setSize(w, h, false) which sets the
+     drawing buffer but NOT the CSS size, so on devicePixelRatio>1 (phones) the
+     canvas would otherwise display at 2-3x and overflow — leaving only the
+     top-left visible and the centred model stranded in the bottom-right. */
+  canvas { display: block; width: 100% !important; height: 100% !important; touch-action: none; }
   * { box-sizing: border-box; }
 </style>
 </head>

--- a/src/app/PuzzleShell.tsx
+++ b/src/app/PuzzleShell.tsx
@@ -21,9 +21,12 @@ import { SoundManager } from '../services/SoundManager';
 import { PUZZLE_CATEGORIES, BLANK_PUZZLE } from '../config/puzzleCategories';
 import { recordCompletion } from '../store/completionTracker';
 import { useUserStore } from '../store/userStore';
+import { useIsMobile } from '../hooks/useMediaQuery';
+import { MobilePuzzlePlay } from '../components/layout/MobilePuzzlePlay';
 
-import { Save, Upload, ArchiveRestore, BookOpen, PanelLeftOpen, PanelRightOpen, GraduationCap, Lightbulb } from 'lucide-react';
+import { Save, Upload, ArchiveRestore, BookOpen, PanelLeftOpen, PanelRightOpen, GraduationCap, Lightbulb, Eye, Braces, ListChecks, CodeXml, Pencil } from 'lucide-react';
 import { CellPickerOverlay } from '../components/editor/ruleBuilder/CellPickerOverlay';
+import { useRuleBuilderStore } from '../components/editor/ruleBuilder/useRuleBuilderStore';
 
 // Lazy-loaded heavy components
 const PuzzleEditor = React.lazy(() =>
@@ -242,6 +245,7 @@ function SidePanel({ puzzle, showInfo, setShowInfo, activeEngine, validationResu
 }
 
 function PreviewPanel() {
+  const isMobile = useIsMobile();
   const puzzle = usePuzzleStore((s) => s.puzzle);
   const storeIsComplete = usePuzzleStore((s) => s.isComplete);
   const storeMoveCount = usePuzzleStore((s) => s.moveCount);
@@ -389,20 +393,36 @@ function PreviewPanel() {
     usePuzzleStore.setState({ puzzle: next, jsonSource: JSON.stringify(next, null, 2) });
   };
 
+  const rendererEl = (
+    <RendererPanel is2D={is2D} isPlugin={isPlugin} engine={engine} viewMode={viewMode} puzzle={puzzle} pluginResetSignal={pluginResetSignal} onPluginState={handlePluginState} onPluginComplete={() => setPluginComplete(true)} onPluginMeta={handlePluginMeta} />
+  );
+
   return (
     <>
-      <ResizablePanels direction="horizontal" defaultSize={panelFlipped ? 30 : 70} minSize={18} maxSize={82}>
-        {panelFlipped ? (
-          <SidePanel puzzle={puzzle} showInfo={showInfo} setShowInfo={setShowInfo} activeEngine={activeEngine} validationResults={validationResults} isComplete={isComplete} flipped />
-        ) : (
-          <RendererPanel is2D={is2D} isPlugin={isPlugin} engine={engine} viewMode={viewMode} puzzle={puzzle} pluginResetSignal={pluginResetSignal} onPluginState={handlePluginState} onPluginComplete={() => setPluginComplete(true)} onPluginMeta={handlePluginMeta} />
-        )}
-        {panelFlipped ? (
-          <RendererPanel is2D={is2D} isPlugin={isPlugin} engine={engine} viewMode={viewMode} puzzle={puzzle} pluginResetSignal={pluginResetSignal} onPluginState={handlePluginState} onPluginComplete={() => setPluginComplete(true)} onPluginMeta={handlePluginMeta} />
-        ) : (
-          <SidePanel puzzle={puzzle} showInfo={showInfo} setShowInfo={setShowInfo} activeEngine={activeEngine} validationResults={validationResults} isComplete={isComplete} />
-        )}
-      </ResizablePanels>
+      {isMobile ? (
+        <MobilePuzzlePlay
+          renderer={rendererEl}
+          puzzle={puzzle}
+          activeEngine={activeEngine}
+          validationResults={validationResults}
+          isComplete={isComplete}
+          showInfo={showInfo}
+          setShowInfo={setShowInfo}
+        />
+      ) : (
+        <ResizablePanels direction="horizontal" defaultSize={panelFlipped ? 30 : 70} minSize={18} maxSize={82}>
+          {panelFlipped ? (
+            <SidePanel puzzle={puzzle} showInfo={showInfo} setShowInfo={setShowInfo} activeEngine={activeEngine} validationResults={validationResults} isComplete={isComplete} flipped />
+          ) : (
+            rendererEl
+          )}
+          {panelFlipped ? (
+            rendererEl
+          ) : (
+            <SidePanel puzzle={puzzle} showInfo={showInfo} setShowInfo={setShowInfo} activeEngine={activeEngine} validationResults={validationResults} isComplete={isComplete} />
+          )}
+        </ResizablePanels>
+      )}
 
       <PuzzleInfoPopup isOpen={showInfo} onClose={() => setShowInfo(false)} engine={activeEngine} />
 
@@ -441,12 +461,92 @@ function SplitView() {
   );
 }
 
+/** Single-pane wrapper that keeps a tab mounted but hidden when inactive. */
+function EditorPane({ active, children }: { active: boolean; children: React.ReactNode }) {
+  return <div className={`absolute inset-0 ${active ? '' : 'hidden'}`}>{children}</div>;
+}
+
+/**
+ * Dedicated mobile editor: a full-screen tabbed surface (Board / JSON / Rules /
+ * Code) with a thumb-reachable bottom tab bar, replacing the desktop
+ * side-by-side split. The Board tab stays mounted so the live preview / engine
+ * state and the rule-builder cell picker persist across tab switches; when a
+ * cell picker is armed we auto-switch to Board so the author can tap cells.
+ */
+function MobileEditorTabs({ preview }: { preview: React.ReactNode }) {
+  const [tab, setTab] = useState<'board' | 'json' | 'rules' | 'plugin'>('board');
+  const [visited, setVisited] = useState<Set<string>>(() => new Set(['board']));
+  const pickerArmed = useRuleBuilderStore(
+    (s) => s.cellPickerTarget !== null || s.singleCellPickerTarget !== null,
+  );
+
+  useEffect(() => {
+    if (pickerArmed) setTab('board');
+  }, [pickerArmed]);
+
+  const go = (t: 'board' | 'json' | 'rules' | 'plugin') => {
+    setTab(t);
+    setVisited((v) => (v.has(t) ? v : new Set(v).add(t)));
+  };
+
+  const TABS = [
+    { id: 'board' as const, label: 'Board', icon: <Eye className="w-5 h-5" /> },
+    { id: 'json' as const, label: 'JSON', icon: <Braces className="w-5 h-5" /> },
+    { id: 'rules' as const, label: 'Rules', icon: <ListChecks className="w-5 h-5" /> },
+    { id: 'plugin' as const, label: 'Code', icon: <CodeXml className="w-5 h-5" /> },
+  ];
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 min-h-0 relative">
+        <EditorPane active={tab === 'board'}>{preview}</EditorPane>
+        {visited.has('json') && (
+          <EditorPane active={tab === 'json'}>
+            <Suspense fallback={<EditorSkeleton />}>
+              <PuzzleEditor className="h-full" />
+            </Suspense>
+          </EditorPane>
+        )}
+        {visited.has('rules') && (
+          <EditorPane active={tab === 'rules'}>
+            <Suspense fallback={<EditorSkeleton />}>
+              <RuleBuilderPanel className="h-full" />
+            </Suspense>
+          </EditorPane>
+        )}
+        {visited.has('plugin') && (
+          <EditorPane active={tab === 'plugin'}>
+            <Suspense fallback={<EditorSkeleton />}>
+              <PluginCodeEditor className="h-full" />
+            </Suspense>
+          </EditorPane>
+        )}
+      </div>
+      <div className="shrink-0 grid grid-cols-4 bg-[var(--surface-raised)] border-t border-border pb-safe">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => go(t.id)}
+            className={`h-12 flex flex-col items-center justify-center gap-0.5 text-[10px] font-medium transition-colors ${
+              tab === t.id ? 'text-primary' : 'text-muted-foreground'
+            }`}
+          >
+            {t.icon}
+            <span>{t.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 interface PuzzleShellProps {
   visible: boolean;
 }
 
 export function PuzzleShell({ visible }: PuzzleShellProps) {
-  const isMobile = () => window.innerWidth < 640;
+  const isMobile = useIsMobile();
   const location = useLocation();
   const navigate = useNavigate();
   const isCreateRoute = location.pathname === '/create';
@@ -469,7 +569,7 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
   const userRole = useUserStore((s) => s.profile?.role);
 
   const [mountedModes, setMountedModes] = useState<Set<EditorViewMode>>(() =>
-    new Set([isMobile() ? 'preview' : (isEditRoute ? 'split' : 'preview')])
+    new Set([(typeof window !== 'undefined' && window.innerWidth < 768) ? 'preview' : (isEditRoute ? 'split' : 'preview')])
   );
   const [hasEverBeenVisible, setHasEverBeenVisible] = useState(visible);
   const [puzzleStatus, setPuzzleStatus] = useState<'draft' | 'published' | null>(null);
@@ -479,7 +579,7 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
 
   // Initialize view mode on first mount
   useEffect(() => {
-    const initial: EditorViewMode = isMobile() ? 'preview' : (isEditRoute ? 'split' : 'preview');
+    const initial: EditorViewMode = isMobile ? 'preview' : (isEditRoute ? 'split' : 'preview');
     setViewMode(initial);
     setIsEditRoute(isEditRoute);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -589,14 +689,11 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
     setMountedModes(new Set([viewMode]));
   }, [viewMode]);
 
-  // Mobile auto-switch
+  // Mobile auto-switch: phones use the dedicated single-surface play/editor
+  // layouts (no side-by-side split/editor view modes).
   useEffect(() => {
-    const handleResize = () => {
-      if (isMobile() && viewMode !== 'preview') setViewMode('preview');
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [viewMode, setViewMode]);
+    if (isMobile && viewMode !== 'preview') setViewMode('preview');
+  }, [isMobile, viewMode, setViewMode]);
 
   // Save draft to API (create new or update existing)
   const handleSaveDraft = () => {
@@ -710,7 +807,7 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
     }`}>
       {/* Creator toolbar — shown for owners and admins */}
       {(isEditRoute || isOwnPuzzle || userRole === 'admin') && visible && (
-        <div className="flex items-center gap-2 px-4 py-2 bg-card/80 backdrop-blur-sm border-b border-border shrink-0 z-20">
+        <div className="flex flex-wrap items-center gap-2 gap-y-1.5 px-3 sm:px-4 py-2 bg-card/80 backdrop-blur-sm border-b border-border shrink-0 z-20">
           <span className="text-xs text-muted-foreground">
             {isCreateRoute ? 'New Puzzle' : `Editing: ${usePuzzleStore.getState().puzzle?.title || slug}`}
           </span>
@@ -732,6 +829,12 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
               </button>
             ))}
           </div>
+          {/* Mobile: jump into the tabbed editor (no desktop view-mode toggle) */}
+          {isMobile && !isEditRoute && slug && (
+            <Button variant="default" size="sm" className="h-7 gap-1.5 text-xs" onClick={() => navigate(`/puzzle/${slug}/edit`)}>
+              <Pencil className="h-3 w-3" />Edit
+            </Button>
+          )}
           <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" onClick={handleSaveDraft}>
             <Save className="h-3 w-3" />{puzzleStatus === 'published' ? 'Save' : 'Save Draft'}
           </Button>
@@ -755,20 +858,30 @@ export function PuzzleShell({ visible }: PuzzleShellProps) {
           <p className="text-sm text-muted-foreground">Loading puzzle...</p>
         </div>
       )}
-      {mountedModes.has('split') && (
-        <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'split' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
-          <SplitView />
+      {isMobile ? (
+        /* Mobile: a single full-screen surface. Edit routes get the tabbed
+           editor (Board/JSON/Rules/Code); play routes get the play layout. */
+        <div className="absolute inset-0">
+          {isEditRoute ? <MobileEditorTabs preview={<PreviewPanel />} /> : <PreviewPanel />}
         </div>
-      )}
-      {mountedModes.has('editor') && (
-        <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'editor' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
-          <EditorPanel />
-        </div>
-      )}
-      {mountedModes.has('preview') && (
-        <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'preview' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
-          <PreviewPanel />
-        </div>
+      ) : (
+        <>
+          {mountedModes.has('split') && (
+            <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'split' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
+              <SplitView />
+            </div>
+          )}
+          {mountedModes.has('editor') && (
+            <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'editor' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
+              <EditorPanel />
+            </div>
+          )}
+          {mountedModes.has('preview') && (
+            <div className={`absolute inset-0 transition-opacity duration-150 ease-out ${viewMode === 'preview' ? 'opacity-100 z-10' : 'opacity-0 z-0 pointer-events-none'}`}>
+              <PreviewPanel />
+            </div>
+          )}
+        </>
       )}
       </div>
     </div>

--- a/src/app/RootLayout.tsx
+++ b/src/app/RootLayout.tsx
@@ -6,6 +6,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { Toaster, toast } from 'sonner';
 import { Header } from '../components/layout/Header';
 import { Sidebar } from '../components/layout/Sidebar';
+import { MobileNav } from '../components/layout/MobileNav';
 import { PuzzleShell } from './PuzzleShell';
 import { KeyboardShortcutsOverlay } from '../components/ui/KeyboardShortcutsOverlay';
 import { usePuzzleStore } from '../store/puzzleStore';
@@ -301,7 +302,7 @@ export function RootLayout() {
   return (
     <LazyMotion features={domAnimation}>
       <Sentry.ErrorBoundary fallback={<div className="flex items-center justify-center h-screen text-foreground">Something went wrong. Please refresh the page.</div>}>
-        <div className="h-screen w-screen flex flex-col overflow-hidden">
+        <div className="h-full w-full flex flex-col overflow-hidden">
           {/* Animated Lego brick background — hidden on puzzle routes */}
           {!isPuzzleRoute && <LegoBackground />}
           <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md">
@@ -333,10 +334,15 @@ export function RootLayout() {
             </main>
           </div>
 
+          {/* Mobile bottom navigation — primary nav on phones (non-puzzle routes) */}
+          {!isPuzzleRoute && <MobileNav />}
+
           <Toaster
             position="bottom-center"
             theme="dark"
             richColors
+            // Lift toasts above the mobile bottom nav / home indicator.
+            mobileOffset={{ bottom: 'calc(env(safe-area-inset-bottom) + 76px)' }}
             toastOptions={{
               className: 'font-sans',
               style: { background: 'var(--card)', border: '1px solid var(--border)' },

--- a/src/app/routes/AdminPage.tsx
+++ b/src/app/routes/AdminPage.tsx
@@ -82,7 +82,7 @@ export default function AdminPage() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
       <div className="flex items-center gap-3 mb-6">
         <Button asChild variant="ghost" size="sm">
           <Link to="/"><ArrowLeft className="h-4 w-4" /></Link>
@@ -122,58 +122,60 @@ export default function AdminPage() {
           }).map((u) => (
             <div
               key={u._id}
-              className={`flex items-center gap-3 p-4 rounded-xl bg-card border transition-colors ${
+              className={`flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-xl bg-card border transition-colors ${
                 u.isBanned ? 'border-destructive/30 bg-destructive/5' : 'border-border'
               }`}
             >
-              {u.avatarUrl ? (
-                <img src={u.avatarUrl} alt="" className="w-9 h-9 rounded-full shrink-0" />
-              ) : (
-                <div className="w-9 h-9 rounded-full bg-primary/20 flex items-center justify-center text-sm font-bold text-primary shrink-0">
-                  {(u.displayName || u.username)[0]?.toUpperCase()}
-                </div>
-              )}
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                {u.avatarUrl ? (
+                  <img src={u.avatarUrl} alt="" className="w-9 h-9 rounded-full shrink-0" />
+                ) : (
+                  <div className="w-9 h-9 rounded-full bg-primary/20 flex items-center justify-center text-sm font-bold text-primary shrink-0">
+                    {(u.displayName || u.username)[0]?.toUpperCase()}
+                  </div>
+                )}
 
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-foreground truncate">
-                    {u.displayName || u.username}
-                  </span>
-                  {u.role === 'admin' && (
-                    <Badge className="text-[10px] bg-primary/20 text-primary border-primary/30">Admin</Badge>
-                  )}
-                  {u.isBanned && (
-                    <Badge variant="destructive" className="text-[10px]">Banned</Badge>
-                  )}
-                </div>
-                <div className="text-xs text-muted-foreground flex gap-3">
-                  <span>Lvl {u.level}</span>
-                  <span>{u.xp} XP</span>
-                  <span>{u.puzzlesCreated} created</span>
-                  <span>{u.puzzlesCompleted} solved</span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground truncate">
+                      {u.displayName || u.username}
+                    </span>
+                    {u.role === 'admin' && (
+                      <Badge className="text-[10px] bg-primary/20 text-primary border-primary/30">Admin</Badge>
+                    )}
+                    {u.isBanned && (
+                      <Badge variant="destructive" className="text-[10px]">Banned</Badge>
+                    )}
+                  </div>
+                  <div className="text-xs text-muted-foreground flex flex-wrap gap-x-3 gap-y-0.5">
+                    <span>Lvl {u.level}</span>
+                    <span>{u.xp} XP</span>
+                    <span>{u.puzzlesCreated} created</span>
+                    <span>{u.puzzlesCompleted} solved</span>
+                  </div>
                 </div>
               </div>
 
-              <div className="flex items-center gap-1.5 shrink-0">
+              <div className="flex items-center gap-1.5 shrink-0 self-end sm:self-auto">
                 {u._id === myUserId ? (
                   <Badge variant="outline" className="text-[10px]">You</Badge>
                 ) : (
                   <>
                     {u.role === 'admin' ? (
-                      <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs" onClick={() => updateUser(u._id, { role: 'user' })} title="Remove admin">
+                      <Button variant="ghost" size="sm" className="h-10 sm:h-8 gap-1.5 text-xs" onClick={() => updateUser(u._id, { role: 'user' })} title="Remove admin">
                         <ShieldOff className="h-3.5 w-3.5" />Demote
                       </Button>
                     ) : (
-                      <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs" onClick={() => updateUser(u._id, { role: 'admin' })} title="Make admin">
+                      <Button variant="ghost" size="sm" className="h-10 sm:h-8 gap-1.5 text-xs" onClick={() => updateUser(u._id, { role: 'admin' })} title="Make admin">
                         <Shield className="h-3.5 w-3.5" />Promote
                       </Button>
                     )}
                     {u.isBanned ? (
-                      <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs text-success" onClick={() => updateUser(u._id, { isBanned: false })} title="Unban user">
+                      <Button variant="ghost" size="sm" className="h-10 sm:h-8 gap-1.5 text-xs text-success" onClick={() => updateUser(u._id, { isBanned: false })} title="Unban user">
                         <CheckCircle className="h-3.5 w-3.5" />Unban
                       </Button>
                     ) : (
-                      <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs text-destructive" onClick={() => updateUser(u._id, { isBanned: true })} title="Ban user">
+                      <Button variant="ghost" size="sm" className="h-10 sm:h-8 gap-1.5 text-xs text-destructive" onClick={() => updateUser(u._id, { isBanned: true })} title="Ban user">
                         <Ban className="h-3.5 w-3.5" />Ban
                       </Button>
                     )}

--- a/src/app/routes/GalleryPage.tsx
+++ b/src/app/routes/GalleryPage.tsx
@@ -262,6 +262,8 @@ export default function GalleryPage() {
               onCategoryChange={setCategory}
               selectedDifficulty={difficulty}
               onDifficultyChange={setDifficulty}
+              sort={sort}
+              onSortChange={setSort}
             />
           )}
         </div>

--- a/src/app/routes/LeaderboardPage.tsx
+++ b/src/app/routes/LeaderboardPage.tsx
@@ -133,9 +133,12 @@ export default function LeaderboardPage() {
                   </div>
                 </div>
 
-                {/* Mobile: compact XP + streak */}
+                {/* Mobile: compact XP + solved/level + streak */}
                 <div className="sm:hidden text-right">
                   <p className="text-sm font-bold text-foreground">{entry.xp.toLocaleString()} XP</p>
+                  <p className="text-[11px] text-muted-foreground tabular-nums">
+                    {entry.puzzlesCompleted} solved &middot; Lv.{entry.level}
+                  </p>
                   {entry.streakDays > 0 && (
                     <p className="text-[11px] text-orange-400 flex items-center gap-1 justify-end">
                       <Flame className="h-3 w-3" />{entry.streakDays}d

--- a/src/app/routes/MyPuzzlesPage.tsx
+++ b/src/app/routes/MyPuzzlesPage.tsx
@@ -95,7 +95,7 @@ export default function MyPuzzlesPage() {
 
   return (
     <div className="px-4 sm:px-6 py-6">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <div>
           <h1 className="text-2xl font-bold text-foreground flex items-center gap-2.5">
             <div className="w-9 h-9 rounded-lg bg-primary/15 flex items-center justify-center">
@@ -142,7 +142,7 @@ export default function MyPuzzlesPage() {
                       {style.label}
                     </Badge>
                   </div>
-                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                     <span>{p.category}</span>
                     <span className="capitalize">{p.difficulty}</span>
                     {p.status === 'published' && (
@@ -159,7 +159,7 @@ export default function MyPuzzlesPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0 hover:bg-primary/10 hover:text-primary"
+                    className="h-10 w-10 sm:h-8 sm:w-8 p-0 hover:bg-primary/10 hover:text-primary"
                     onClick={() => navigate(`/puzzle/${p.slug}`)}
                     title="Preview"
                   >
@@ -168,7 +168,7 @@ export default function MyPuzzlesPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0 hover:bg-primary/10 hover:text-primary"
+                    className="h-10 w-10 sm:h-8 sm:w-8 p-0 hover:bg-primary/10 hover:text-primary"
                     onClick={() => navigate(`/puzzle/${p.slug}/edit`)}
                     title="Edit"
                   >
@@ -177,7 +177,7 @@ export default function MyPuzzlesPage() {
                   <Button
                     variant={deletingSlug === p.slug ? 'destructive' : 'ghost'}
                     size="sm"
-                    className={`h-8 w-8 p-0 ${deletingSlug !== p.slug ? 'hover:bg-destructive/10 hover:text-destructive' : ''}`}
+                    className={`h-10 w-10 sm:h-8 sm:w-8 p-0 ${deletingSlug !== p.slug ? 'hover:bg-destructive/10 hover:text-destructive' : ''}`}
                     onClick={() => handleDelete(p.slug)}
                     title={deletingSlug === p.slug ? 'Click again to confirm' : 'Delete'}
                   >

--- a/src/app/routes/ProfilePage.tsx
+++ b/src/app/routes/ProfilePage.tsx
@@ -351,31 +351,33 @@ function GroupedCompletions({ completions }: { completions: CompletionEntry[] })
         const isOpen = expanded.has(g.slug);
         return (
           <div key={g.slug}>
-            <div className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-muted/20 transition-colors" onClick={() => toggle(g.slug)}>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-3 cursor-pointer hover:bg-muted/20 transition-colors" onClick={() => toggle(g.slug)}>
               <Puzzle className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div className="flex-1 min-w-0">
+              <div className="flex-1 min-w-[8rem]">
                 <p className="text-sm font-medium text-foreground truncate">{g.title}</p>
                 <p className="text-xs text-muted-foreground">
                   Best: {g.bestMoves} moves &middot; {g.bestTime}s &middot; Solved {g.solveCount}{g.solveCount === 1 ? ' time' : ' times'}
                 </p>
               </div>
-              {g.totalXp > 0 && (
-                <span className="text-xs font-bold text-primary shrink-0">+{g.totalXp} XP</span>
-              )}
-              <Link
-                to={`/puzzle/${g.slug}`}
-                className="shrink-0 flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 border border-primary/20 transition-colors"
-                onClick={e => e.stopPropagation()}
-              >
-                <Play className="h-3 w-3" />
-                Play
-              </Link>
-              <ChevronDown className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+              <div className="flex items-center gap-3 shrink-0 ml-auto">
+                {g.totalXp > 0 && (
+                  <span className="text-xs font-bold text-primary shrink-0">+{g.totalXp} XP</span>
+                )}
+                <Link
+                  to={`/puzzle/${g.slug}`}
+                  className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 border border-primary/20 transition-colors"
+                  onClick={e => e.stopPropagation()}
+                >
+                  <Play className="h-3 w-3" />
+                  Play
+                </Link>
+                <ChevronDown className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+              </div>
             </div>
             {isOpen && (
               <div className="border-t border-border bg-muted/10 px-4 py-2 space-y-1">
                 {g.solves.map((s, i) => (
-                  <div key={i} className="flex items-center gap-3 text-xs text-muted-foreground py-1">
+                  <div key={i} className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground py-1">
                     <span className="w-24 shrink-0">{new Date(s.completedAt).toLocaleDateString()}</span>
                     <span>{s.moveCount} moves</span>
                     <span>&middot;</span>

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -1036,6 +1036,9 @@ function PuzzleSceneInner() {
   const isMobile = useIsMobile();
   // Compact = touch device OR phone-width: show on-screen rotate/remove/done.
   const compact = isTouch || isMobile;
+  // Reserve a bottom strip for the control bar (container padding) so it never
+  // overlaps the board; the R3F canvas re-fits into the space above it.
+  const showTouchControls = compact && !!(selectedPlacedBrick || selectedInventoryBrick);
 
   // Hide cursor when any brick is selected for placement/movement (mouse only)
   const shouldHideCursor = !isTouch && (hasInventorySelection || hasPlacedBrickSelection);
@@ -1063,7 +1066,7 @@ function PuzzleSceneInner() {
 
   return (
     <div
-      className={`w-full h-full relative transition-opacity duration-300 ${sceneReady ? 'opacity-100' : 'opacity-0'}`}
+      className={`w-full h-full relative transition-opacity duration-300 ${showTouchControls ? 'pb-20' : ''} ${sceneReady ? 'opacity-100' : 'opacity-0'}`}
       style={{ cursor: shouldHideCursor ? 'none' : 'auto', backgroundColor: '#0f1520', touchAction: 'none' }}
       onContextMenu={(e) => {
         if (hasInventorySelection) {
@@ -1141,8 +1144,10 @@ function PuzzleSceneInner() {
       </Canvas>
 
       {/* Touch control bar — rotate/remove/deselect replace the keyboard R,
-          right-click and double-click which are unavailable on a phone. */}
-      {compact && (selectedPlacedBrick || selectedInventoryBrick) && (
+          right-click and double-click which are unavailable on a phone.
+          Sits in the reserved bottom strip (wrapper pb-20) to avoid covering
+          the board. */}
+      {showTouchControls && (
         <div className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 flex items-center gap-2 px-2 py-1.5 rounded-full bg-black/70 backdrop-blur-sm border border-white/15 shadow-lg">
           <button
             type="button"

--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -12,6 +12,8 @@ import { SHAPE_LIBRARY } from '../../types/puzzle';
 import { getBrickCells, rotateShape } from '../../validation/ValidationRegistry';
 import { applySnapZones, getFootprintExtent } from '../../engine/utils';
 import { SCENE_3D, GOAL_INDICATOR_3D, COLORS } from '../../config/sceneConfig';
+import { useIsTouch, useIsMobile } from '../../hooks/useMediaQuery';
+import { RotateCw, Trash2, Check } from 'lucide-react';
 
 // Error boundary to catch Three.js / WebGL crashes gracefully
 class SceneErrorBoundary extends React.Component<
@@ -307,6 +309,18 @@ function DragDropManager({ setOrbitEnabled }: { setOrbitEnabled: (enabled: boole
   const { width, height } = boardState.dimensions;
   const boardOffset = { x: width / 2, y: height / 2 };
 
+  // Resolve a board cell directly from a pointer event's world intersection
+  // point. Used as a fallback on touch where a tap may not produce a
+  // pointermove, so `hoveredCell` (set only on raycasted move) can be stale.
+  const cellFromEvent = (event: any): { x: number; y: number } | null => {
+    const p = event?.point;
+    if (!p) return null;
+    const cx = Math.floor(p.x + boardOffset.x);
+    const cy = Math.floor(p.z + boardOffset.y);
+    if (cx < 0 || cx >= width || cy < 0 || cy >= height) return null;
+    return { x: cx, y: cy };
+  };
+
   // Default-on: puzzles without an explicit dragNdrop setting use the
   // press-drag-release flow. Opt out by setting `dragNdrop: false`.
   const dragNdrop = puzzle?.dragNdrop ?? true;
@@ -599,7 +613,7 @@ function DragDropManager({ setOrbitEnabled }: { setOrbitEnabled: (enabled: boole
     // release commits exactly one action.
     if (selectedInventoryBrick) {
       event.stopPropagation?.();
-      const current = useHoverStore.getState().hoveredCell;
+      const current = useHoverStore.getState().hoveredCell ?? cellFromEvent(event);
       if (!current) return;
       placeInventoryAt(current.x, current.y);
       return;
@@ -622,12 +636,15 @@ function DragDropManager({ setOrbitEnabled }: { setOrbitEnabled: (enabled: boole
         if (typeof ne?.clientX === 'number') {
           const dx = ne.clientX - start.x;
           const dy = ne.clientY - start.y;
-          const moved = Math.sqrt(dx * dx + dy * dy) >= DRAG_THRESHOLD_PX;
+          // Fingers jitter more than a mouse — use a larger threshold for touch
+          // so a tap-to-select isn't misread as a (no-op) drag-move.
+          const threshold = ne.pointerType === 'touch' ? 12 : DRAG_THRESHOLD_PX;
+          const moved = Math.sqrt(dx * dx + dy * dy) >= threshold;
           if (!moved) return;
         }
       }
 
-      const current = useHoverStore.getState().hoveredCell;
+      const current = useHoverStore.getState().hoveredCell ?? cellFromEvent(event);
       if (!current) return; // released off-board
 
       const shape = SHAPE_LIBRARY[selectedPlacedBrick.shape];
@@ -1015,18 +1032,39 @@ function PuzzleSceneInner() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [selectedPlacedBrick, selectedInventoryBrick, rotateBrick, rotatePreview, selectBrick, removeBrick]);
 
-  // Hide cursor when any brick is selected for placement/movement
-  const shouldHideCursor = hasInventorySelection || hasPlacedBrickSelection;
+  const isTouch = useIsTouch();
+  const isMobile = useIsMobile();
+  // Compact = touch device OR phone-width: show on-screen rotate/remove/done.
+  const compact = isTouch || isMobile;
+
+  // Hide cursor when any brick is selected for placement/movement (mouse only)
+  const shouldHideCursor = !isTouch && (hasInventorySelection || hasPlacedBrickSelection);
   const boardCellCount = boardState.dimensions.width * boardState.dimensions.height;
   const isLargeBoard = boardCellCount >= 400;
   const effectiveDpr = isLargeBoard
     ? ([1, 1.5] as [number, number])
     : (SCENE_3D.renderer.dpr as unknown as [number, number]);
 
+  // Camera framing: pull back on phones and for large boards, and raise the
+  // zoom-out limit so the whole board can be framed by pinch on a narrow
+  // portrait viewport (the user can always pinch back in to maxZoom).
+  const maxDim = Math.max(boardState.dimensions.width, boardState.dimensions.height);
+  const camFactor = (isMobile ? 1.35 : 1) * Math.max(1, maxDim / 8);
+  const cameraPosition = (SCENE_3D.camera.position as readonly number[]).map(
+    (c) => c * camFactor,
+  ) as unknown as [number, number, number];
+  const maxDistance = Math.max(SCENE_3D.camera.maxZoom, maxDim * 3.2);
+
+  // Context actions for the touch control bar.
+  const handleTouchRotate = () => {
+    if (selectedPlacedBrick) rotateBrick(selectedPlacedBrick.instanceId);
+    else if (selectedInventoryBrick) rotatePreview();
+  };
+
   return (
     <div
       className={`w-full h-full relative transition-opacity duration-300 ${sceneReady ? 'opacity-100' : 'opacity-0'}`}
-      style={{ cursor: shouldHideCursor ? 'none' : 'auto', backgroundColor: '#0f1520' }}
+      style={{ cursor: shouldHideCursor ? 'none' : 'auto', backgroundColor: '#0f1520', touchAction: 'none' }}
       onContextMenu={(e) => {
         if (hasInventorySelection) {
           e.preventDefault();
@@ -1060,7 +1098,7 @@ function PuzzleSceneInner() {
       >
         <PerspectiveCamera
           makeDefault
-          position={SCENE_3D.camera.position as unknown as [number, number, number]}
+          position={cameraPosition}
           fov={SCENE_3D.camera.fov}
         />
 
@@ -1073,7 +1111,7 @@ function PuzzleSceneInner() {
           enableDamping
           dampingFactor={0.08}
           minDistance={SCENE_3D.camera.minZoom}
-          maxDistance={SCENE_3D.camera.maxZoom}
+          maxDistance={maxDistance}
           maxPolarAngle={SCENE_3D.camera.maxPolarAngle}
           target={SCENE_3D.camera.target as unknown as [number, number, number]}
         />
@@ -1101,6 +1139,44 @@ function PuzzleSceneInner() {
         {/* Subtle fog for depth */}
         <fog attach="fog" args={[SCENE_3D.fog.color, SCENE_3D.fog.near, SCENE_3D.fog.far]} />
       </Canvas>
+
+      {/* Touch control bar — rotate/remove/deselect replace the keyboard R,
+          right-click and double-click which are unavailable on a phone. */}
+      {compact && (selectedPlacedBrick || selectedInventoryBrick) && (
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 flex items-center gap-2 px-2 py-1.5 rounded-full bg-black/70 backdrop-blur-sm border border-white/15 shadow-lg">
+          <button
+            type="button"
+            aria-label="Rotate brick"
+            className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-white/90 text-xs font-medium active:scale-95 transition-transform"
+            onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); handleTouchRotate(); }}
+          >
+            <RotateCw className="w-5 h-5" /> Rotate
+          </button>
+          {selectedPlacedBrick && (
+            <button
+              type="button"
+              aria-label="Remove brick"
+              className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-red-300 text-xs font-medium active:scale-95 transition-transform"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                removeBrick(selectedPlacedBrick.instanceId);
+                selectBrick(null);
+              }}
+            >
+              <Trash2 className="w-5 h-5" /> Remove
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Done"
+            className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-white/90 text-xs font-medium active:scale-95 transition-transform"
+            onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); selectBrick(null); }}
+          >
+            <Check className="w-5 h-5" /> Done
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/editor/PluginCodeEditor.tsx
+++ b/src/components/editor/PluginCodeEditor.tsx
@@ -3,6 +3,7 @@ import Editor, { type OnMount } from '@monaco-editor/react';
 import type * as monaco from 'monaco-editor';
 import './monacoSetup'; // side effect: configures MonacoEnvironment + loader
 import { usePuzzleStore } from '../../store/puzzleStore';
+import { useIsMobile } from '../../hooks/useMediaQuery';
 import type { PuzzleDefinition, PluginRenderKind } from '../../types/puzzle';
 import { RUBIKS_CUBE_PLUGIN_SOURCE } from '../../runtime/plugin/examples/rubiksCubePlugin';
 import { ACYCLIC_SHADOWS_PLUGIN_SOURCE } from '../../runtime/plugin/examples/acyclicShadowsPlugin';
@@ -116,6 +117,7 @@ interface PluginCodeEditorProps {
 }
 
 export function PluginCodeEditor({ className = '' }: PluginCodeEditorProps) {
+  const isMobile = useIsMobile();
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const setPuzzle = usePuzzleStore((s) => s.setPuzzle);
   const currentPuzzle = usePuzzleStore((s) => s.puzzle);
@@ -206,13 +208,17 @@ export function PluginCodeEditor({ className = '' }: PluginCodeEditorProps) {
           onChange={(v) => { codeRef.current = v ?? ''; }}
           options={{
             minimap: { enabled: false },
-            fontSize: 13,
+            fontSize: isMobile ? 16 : 13,
             fontFamily: "'JetBrains Mono', monospace",
+            lineNumbers: isMobile ? 'off' : 'on',
             wordWrap: 'on',
             scrollBeyondLastLine: false,
             automaticLayout: true,
             tabSize: 2,
-            scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+            scrollbar: {
+              verticalScrollbarSize: isMobile ? 14 : 8,
+              horizontalScrollbarSize: isMobile ? 14 : 8,
+            },
             padding: { top: 12, bottom: 12 },
           }}
           loading={

--- a/src/components/editor/PuzzleEditor.tsx
+++ b/src/components/editor/PuzzleEditor.tsx
@@ -4,6 +4,7 @@ import Editor, { OnMount, OnChange } from '@monaco-editor/react';
 import './monacoSetup'; // side effect: configures MonacoEnvironment + loader
 import { usePuzzleStore } from '../../store/puzzleStore';
 import { PuzzleDefinitionSchema } from '../../types/puzzle';
+import { useIsMobile } from '../../hooks/useMediaQuery';
 import { Button } from '../ui/shadcn/button';
 import { Badge } from '../ui/shadcn/badge';
 import {
@@ -142,6 +143,7 @@ interface PuzzleEditorProps {
 }
 
 export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
+  const isMobile = useIsMobile();
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof import('monaco-editor') | null>(null);
   const { jsonSource, setJsonSource, parseAndLoadPuzzle, parseError } = usePuzzleStore();
@@ -379,15 +381,19 @@ export function PuzzleEditor({ className = '' }: PuzzleEditorProps) {
           onMount={handleEditorMount}
           options={{
             minimap: { enabled: false },
-            fontSize: 13,
+            // >=16px on mobile avoids iOS auto-zooming the page on focus.
+            fontSize: isMobile ? 16 : 13,
             fontFamily: "'JetBrains Mono', monospace",
-            lineNumbers: 'on',
+            lineNumbers: isMobile ? 'off' : 'on',
             wordWrap: 'on',
             scrollBeyondLastLine: false,
             automaticLayout: true,
             tabSize: 2,
             formatOnPaste: true,
-            scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+            scrollbar: {
+              verticalScrollbarSize: isMobile ? 14 : 8,
+              horizontalScrollbarSize: isMobile ? 14 : 8,
+            },
             padding: { top: 12, bottom: 12 },
           }}
           loading={

--- a/src/components/editor/ruleBuilder/CellPickerOverlay.tsx
+++ b/src/components/editor/ruleBuilder/CellPickerOverlay.tsx
@@ -2,6 +2,7 @@ import { useRuleBuilderStore } from './useRuleBuilderStore';
 import { Badge } from '../../ui/shadcn/badge';
 import { Button } from '../../ui/shadcn/button';
 import { Crosshair, Check, Trash2 } from 'lucide-react';
+import { useIsMobile, useIsTouch } from '../../../hooks/useMediaQuery';
 
 export function CellPickerOverlay() {
   const isPickingCells = useRuleBuilderStore(s => s.cellPickerTarget !== null);
@@ -9,6 +10,8 @@ export function CellPickerOverlay() {
   const stopCellPicker = useRuleBuilderStore(s => s.stopCellPicker);
   const clearPickerCells = useRuleBuilderStore(s => s.clearPickerCells);
   const singleTarget = useRuleBuilderStore(s => s.singleCellPickerTarget);
+  const compact = useIsMobile() || useIsTouch();
+  const btnClass = compact ? 'h-10 px-3 text-xs gap-1.5' : 'h-6 text-[10px] gap-1';
 
   // Single-cell picker mode (path_exists start/end)
   if (singleTarget) {
@@ -35,18 +38,18 @@ export function CellPickerOverlay() {
       <Button
         variant="outline"
         size="xs"
-        className="h-6 text-[10px] gap-1"
+        className={btnClass}
         onClick={clearPickerCells}
       >
-        <Trash2 className="w-3 h-3" />
+        <Trash2 className="w-3.5 h-3.5" />
         Clear
       </Button>
       <Button
         size="xs"
-        className="h-6 text-[10px] gap-1 bg-cyan-600 hover:bg-cyan-500"
+        className={`${btnClass} bg-cyan-600 hover:bg-cyan-500`}
         onClick={stopCellPicker}
       >
-        <Check className="w-3 h-3" />
+        <Check className="w-3.5 h-3.5" />
         Done
       </Button>
     </div>

--- a/src/components/editor/ruleBuilder/CellPickerOverlay.tsx
+++ b/src/components/editor/ruleBuilder/CellPickerOverlay.tsx
@@ -10,7 +10,10 @@ export function CellPickerOverlay() {
   const stopCellPicker = useRuleBuilderStore(s => s.stopCellPicker);
   const clearPickerCells = useRuleBuilderStore(s => s.clearPickerCells);
   const singleTarget = useRuleBuilderStore(s => s.singleCellPickerTarget);
-  const compact = useIsMobile() || useIsTouch();
+  // Call both hooks unconditionally (no `||` short-circuit) per rules of hooks.
+  const isMobile = useIsMobile();
+  const isTouch = useIsTouch();
+  const compact = isMobile || isTouch;
   const btnClass = compact ? 'h-10 px-3 text-xs gap-1.5' : 'h-6 text-[10px] gap-1';
 
   // Single-cell picker mode (path_exists start/end)

--- a/src/components/editor/ruleBuilder/ConditionTypePicker.tsx
+++ b/src/components/editor/ruleBuilder/ConditionTypePicker.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { usePuzzleStore } from '../../../store/puzzleStore';
+import { useIsMobile } from '../../../hooks/useMediaQuery';
 import { CONDITION_META, CONDITION_CATEGORIES, type ConditionCategory } from '../../../validation/conditionMeta';
 import type { LeafKind } from '../../../types/customRules';
 import { LEAF_KINDS } from '../../../types/customRules';
@@ -27,11 +28,15 @@ const CATEGORY_ICONS: Record<ConditionCategory, typeof Grid3X3> = {
 export function ConditionTypePicker({ onSelect, onSelectCombinator, onClose, anchorRef }: ConditionTypePickerProps) {
   const [selectedCategory, setSelectedCategory] = useState<ConditionCategory | 'Logic'>('Cell');
   const viewMode = usePuzzleStore(s => s.puzzle?.viewMode ?? '3D');
+  const isMobile = useIsMobile();
   const panelRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
-  // Position the panel relative to the anchor button
+  // Position the panel relative to the anchor button (desktop only — on mobile
+  // it renders as a bottom sheet so it never overflows or sits under the
+  // on-screen keyboard).
   useEffect(() => {
+    if (isMobile) return;
     const anchor = anchorRef.current;
     if (!anchor) return;
     const rect = anchor.getBoundingClientRect();
@@ -52,29 +57,32 @@ export function ConditionTypePicker({ onSelect, onSelectCombinator, onClose, anc
     }
 
     setPos({ top, left: Math.max(8, left) });
-  }, [anchorRef]);
+  }, [anchorRef, isMobile]);
 
-  // Close on outside click
+  // Close on outside press (pointerdown covers mouse + touch)
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
+    const handleClick = (e: Event) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('pointerdown', handleClick);
+    return () => document.removeEventListener('pointerdown', handleClick);
   }, [onClose]);
 
   const content = (
     <div
       ref={panelRef}
-      className="fixed w-[360px] rounded-xl shadow-2xl overflow-hidden border border-[var(--border-default)]"
-      style={{
-        top: pos.top,
-        left: pos.left,
-        zIndex: 9999,
-        backgroundColor: 'var(--surface-raised)',
-      }}
+      className={
+        isMobile
+          ? 'fixed left-0 right-0 bottom-0 rounded-t-2xl shadow-2xl overflow-hidden border-t border-[var(--border-default)] pb-safe'
+          : 'fixed w-[min(360px,calc(100vw-1rem))] rounded-xl shadow-2xl overflow-hidden border border-[var(--border-default)]'
+      }
+      style={
+        isMobile
+          ? { zIndex: 9999, backgroundColor: 'var(--surface-raised)' }
+          : { top: pos.top, left: pos.left, zIndex: 9999, backgroundColor: 'var(--surface-raised)' }
+      }
     >
       {/* Category tabs */}
       <div className="flex flex-wrap gap-1 p-2 border-b border-[var(--border-subtle)]" style={{ backgroundColor: 'var(--surface-sunken)' }}>

--- a/src/components/gallery/GalleryFilters.tsx
+++ b/src/components/gallery/GalleryFilters.tsx
@@ -1,6 +1,14 @@
 import { Button } from '../ui/shadcn/button';
+import type { SortOption } from '../../store/galleryStore';
 
 const DIFFICULTIES = ['easy', 'medium', 'hard', 'expert'] as const;
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'newest', label: 'Newest' },
+  { value: 'popular', label: 'Popular' },
+  { value: 'likes', label: 'Most Liked' },
+  { value: 'difficulty', label: 'Difficulty' },
+];
 
 const DIFFICULTY_COLORS: Record<string, string> = {
   easy: 'bg-green-500/20 text-green-400 border-green-500/30',
@@ -15,6 +23,8 @@ interface GalleryFiltersProps {
   onCategoryChange: (category: string | null) => void;
   selectedDifficulty: string | null;
   onDifficultyChange: (difficulty: string | null) => void;
+  sort: SortOption;
+  onSortChange: (sort: SortOption) => void;
 }
 
 export function GalleryFilters({
@@ -23,9 +33,29 @@ export function GalleryFilters({
   onCategoryChange,
   selectedDifficulty,
   onDifficultyChange,
+  sort,
+  onSortChange,
 }: GalleryFiltersProps) {
   return (
     <div className="mt-3 space-y-3">
+      {/* Sort (mobile only — desktop has the inline sort select) */}
+      <div className="sm:hidden">
+        <label className="text-xs text-muted-foreground uppercase tracking-wider mb-1.5 block">Sort</label>
+        <div className="flex flex-wrap gap-1.5">
+          {SORT_OPTIONS.map(opt => (
+            <Button
+              key={opt.value}
+              variant={sort === opt.value ? 'default' : 'outline'}
+              size="sm"
+              className="h-9 px-3 text-xs"
+              onClick={() => onSortChange(opt.value)}
+            >
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
       {/* Categories */}
       <div>
         <label className="text-xs text-muted-foreground uppercase tracking-wider mb-1.5 block">Category</label>

--- a/src/components/gallery/PuzzleCard.tsx
+++ b/src/components/gallery/PuzzleCard.tsx
@@ -71,13 +71,16 @@ export function PuzzleCard({ puzzle, onClick, onEdit, onLike, isSolved, isLiked 
           </div>
         </div>
 
-        {/* Edit button for owned puzzles */}
+        {/* Edit button for owned puzzles.
+            Hover-reveal on mouse devices; always visible (and a larger tap
+            target) on touch devices where there is no hover. */}
         {onEdit && (
           <div
             role="button"
             tabIndex={0}
-            className="absolute bottom-2.5 right-2.5 z-10 w-8 h-8 rounded-lg bg-background/90 border border-border hover:border-primary/50 hover:bg-primary/20 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all cursor-pointer backdrop-blur-sm"
+            className="absolute bottom-2.5 right-2.5 z-10 w-8 h-8 [@media(hover:none)]:w-10 [@media(hover:none)]:h-10 rounded-lg bg-background/90 border border-border hover:border-primary/50 hover:bg-primary/20 flex items-center justify-center opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-all cursor-pointer backdrop-blur-sm"
             title="Edit puzzle"
+            aria-label="Edit puzzle"
             onClick={(e) => { e.stopPropagation(); onEdit(puzzle.slug); }}
             onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); onEdit(puzzle.slug); } }}
           >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -186,13 +186,13 @@ export function Header({ onChatToggle, isChatOpen, onShowInstructions, isPuzzleR
       </div>
 
       {/* Center: View mode toggle (only on puzzle routes, desktop only) */}
-      <div className="hidden sm:flex flex-1 items-center justify-center">
+      <div className="hidden md:flex flex-1 items-center justify-center">
         {isPuzzleRoute && <ViewModeToggle />}
       </div>
 
       {/* Right: Actions (desktop) */}
       <TooltipProvider delayDuration={300}>
-        <div className="hidden sm:flex items-center gap-1.5 flex-shrink-0 ml-auto">
+        <div className="hidden md:flex items-center gap-1.5 flex-shrink-0 ml-auto">
           {isPuzzleRoute && (undoStack.length > 0 || redoStack.length > 0) && (
             <>
               <Tooltip>
@@ -272,7 +272,7 @@ export function Header({ onChatToggle, isChatOpen, onShowInstructions, isPuzzleR
       </TooltipProvider>
 
       {/* Right: Mobile hamburger menu */}
-      <div className="flex sm:hidden items-center gap-1.5 ml-auto">
+      <div className="flex md:hidden items-center gap-1.5 ml-auto">
         {isPuzzleRoute && (undoStack.length > 0 || redoStack.length > 0) && (
           <>
             <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleUndo} disabled={undoStack.length === 0}>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,93 @@
+import { Link, useLocation } from 'react-router';
+import { Home, Trophy, Plus, FolderOpen, User, LogIn } from 'lucide-react';
+import { Show, SignInButton, useUser } from '../../auth/AuthProvider';
+
+interface TabProps {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  isActive: boolean;
+}
+
+function Tab({ to, icon, label, isActive }: TabProps) {
+  return (
+    <Link
+      to={to}
+      className={`flex flex-1 flex-col items-center justify-center gap-0.5 min-w-0 h-full transition-colors ${
+        isActive ? 'text-primary' : 'text-muted-foreground'
+      }`}
+    >
+      <span className="w-6 h-6 flex items-center justify-center">{icon}</span>
+      <span className="text-[10px] font-medium leading-none truncate max-w-full px-0.5">{label}</span>
+    </Link>
+  );
+}
+
+/**
+ * Mobile bottom tab bar — the primary navigation on phones, replacing the
+ * desktop-only Sidebar (hidden md:flex). Rendered by RootLayout only on
+ * non-puzzle routes at <md; puzzle routes get their own bottom action bar.
+ */
+export function MobileNav() {
+  const location = useLocation();
+  const { user } = useUser();
+  const pathname = location.pathname;
+
+  return (
+    <nav
+      className="md:hidden shrink-0 flex items-stretch h-14 bg-[var(--surface-raised)]/95 backdrop-blur-md border-t border-[var(--border-subtle)] pb-safe z-40"
+      aria-label="Primary"
+    >
+      <Tab to="/" icon={<Home className="h-5 w-5" />} label="Gallery" isActive={pathname === '/'} />
+      <Tab
+        to="/leaderboard"
+        icon={<Trophy className="h-5 w-5" />}
+        label="Ranks"
+        isActive={pathname === '/leaderboard'}
+      />
+
+      {/* Center Create CTA — elevated accent button */}
+      <Link
+        to="/create"
+        className="flex flex-1 flex-col items-center justify-center gap-0.5 min-w-0 h-full"
+        aria-label="Create puzzle"
+      >
+        <span className="w-10 h-10 -mt-3 flex items-center justify-center rounded-full bg-gold text-gold-foreground shadow-lg shadow-gold/30 ring-4 ring-[var(--surface-raised)]">
+          <Plus className="h-5 w-5" />
+        </span>
+        <span className="text-[10px] font-medium leading-none text-gold">Create</span>
+      </Link>
+
+      <Show when="signed-in">
+        <Tab
+          to="/my-puzzles"
+          icon={<FolderOpen className="h-5 w-5" />}
+          label="Puzzles"
+          isActive={pathname === '/my-puzzles'}
+        />
+        <Tab
+          to={`/profile/${user?.id}`}
+          icon={
+            user?.imageUrl ? (
+              <img src={user.imageUrl} alt="" className="h-6 w-6 rounded-full object-cover" />
+            ) : (
+              <User className="h-5 w-5" />
+            )
+          }
+          label="Profile"
+          isActive={pathname.startsWith('/profile/')}
+        />
+      </Show>
+      <Show when="signed-out">
+        <SignInButton mode="modal">
+          <button className="flex flex-1 flex-col items-center justify-center gap-0.5 min-w-0 h-full text-muted-foreground">
+            <span className="w-6 h-6 flex items-center justify-center">
+              <LogIn className="h-5 w-5" />
+            </span>
+            <span className="text-[10px] font-medium leading-none">Sign In</span>
+          </button>
+        </SignInButton>
+      </Show>
+    </nav>
+  );
+}

--- a/src/components/layout/MobilePuzzlePlay.tsx
+++ b/src/components/layout/MobilePuzzlePlay.tsx
@@ -1,0 +1,172 @@
+import { useState, useRef } from 'react';
+import { ChevronDown, GraduationCap, Lightbulb, BookOpen, Package, ListChecks } from 'lucide-react';
+import { InventoryPanel } from '../ui/InventoryPanel';
+import { ValidationPanel } from '../ui/ValidationPanel';
+import { HtmlSandboxModal } from '../ui/HtmlSandboxModal';
+
+type SheetTab = 'inventory' | 'validation';
+
+interface MobilePuzzlePlayProps {
+  renderer: React.ReactNode;
+  puzzle: any;
+  activeEngine: any;
+  validationResults: { rule: string; isValid: boolean; message?: string }[];
+  isComplete: boolean;
+  showInfo: boolean;
+  setShowInfo: (v: boolean) => void;
+}
+
+/**
+ * Dedicated mobile play layout: the board fills the screen and the
+ * inventory / validation live in a collapsible bottom sheet, so both the
+ * board and the pieces are usable on a phone (the desktop side-by-side
+ * ResizablePanels with a 300px side panel can't fit). Tap a brick to select,
+ * then tap a board cell to place (see Renderer2D / PuzzleScene touch handling).
+ */
+export function MobilePuzzlePlay({
+  renderer,
+  puzzle,
+  activeEngine,
+  validationResults,
+  isComplete,
+  showInfo,
+  setShowInfo,
+}: MobilePuzzlePlayProps) {
+  const [open, setOpen] = useState(true);
+  const [tab, setTab] = useState<SheetTab>('inventory');
+  const [showTutorial, setShowTutorial] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+
+  const hasTutorial = typeof puzzle?.tutorial_html === 'string' && puzzle.tutorial_html.length > 0;
+  const hasHint = typeof puzzle?.clue_html === 'string' && puzzle.clue_html.length > 0;
+  const hasInventory = (puzzle?.inventory?.length ?? 0) > 0;
+
+  // Plugin puzzles render their own controls inside the sandbox — no inventory
+  // sheet needed; just show the board full-bleed with the action overlay.
+  const isPlugin = puzzle?.engine === 'plugin';
+
+  const validCount = validationResults.filter((r) => r.isValid).length;
+
+  // Drag-to-toggle the sheet via the grab handle.
+  const dragRef = useRef<{ y: number } | null>(null);
+
+  return (
+    <div className="h-full w-full flex flex-col bg-background overflow-hidden">
+      {/* Board area */}
+      <div className="relative flex-1 min-h-0">
+        {renderer}
+
+        {/* Top-right action overlay: Tutorial / Hint / Rules */}
+        <div className="absolute top-2 right-2 z-10 flex gap-1.5">
+          {hasTutorial && (
+            <OverlayButton label="Tutorial" onClick={() => setShowTutorial(true)}>
+              <GraduationCap className="w-5 h-5" />
+            </OverlayButton>
+          )}
+          {hasHint && (
+            <OverlayButton label="Hint" onClick={() => setShowHint(true)}>
+              <Lightbulb className="w-5 h-5" />
+            </OverlayButton>
+          )}
+          <OverlayButton label="Rules & Controls" onClick={() => setShowInfo(!showInfo)}>
+            <BookOpen className="w-5 h-5" />
+          </OverlayButton>
+        </div>
+      </div>
+
+      {/* Bottom sheet (hidden for plugin puzzles that own their full UI) */}
+      {!isPlugin && (
+        <div
+          className="shrink-0 flex flex-col bg-[var(--surface-raised)] border-t border-border rounded-t-2xl shadow-[0_-8px_24px_rgba(0,0,0,0.35)] transition-[height] duration-200 ease-out pb-safe"
+          style={{ height: open ? 'min(46dvh, 360px)' : '3rem' }}
+        >
+          {/* Grab handle / header — tap or drag to toggle */}
+          <div
+            className="shrink-0 h-12 flex items-center px-3 gap-2 cursor-pointer select-none touch-none"
+            onClick={() => setOpen((o) => !o)}
+            onPointerDown={(e) => {
+              dragRef.current = { y: e.clientY };
+              (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+            }}
+            onPointerUp={(e) => {
+              const start = dragRef.current;
+              dragRef.current = null;
+              if (!start) return;
+              const dy = e.clientY - start.y;
+              if (dy > 24) setOpen(false);
+              else if (dy < -24) setOpen(true);
+            }}
+          >
+            <div className="absolute left-1/2 -translate-x-1/2 top-1.5 w-10 h-1 rounded-full bg-muted-foreground/40" />
+            {/* Segmented tab switcher */}
+            <div className="flex items-center gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
+              {hasInventory && (
+                <SheetTabButton
+                  active={tab === 'inventory'}
+                  onClick={() => { setTab('inventory'); setOpen(true); }}
+                >
+                  <Package className="w-4 h-4" /> Inventory
+                </SheetTabButton>
+              )}
+              <SheetTabButton
+                active={tab === 'validation'}
+                onClick={() => { setTab('validation'); setOpen(true); }}
+              >
+                <ListChecks className="w-4 h-4" /> Validation
+                {validationResults.length > 0 && (
+                  <span className={`ml-1 text-[9px] font-mono px-1 rounded ${isComplete ? 'bg-success/20 text-success' : 'bg-muted text-muted-foreground'}`}>
+                    {validCount}/{validationResults.length}
+                  </span>
+                )}
+              </SheetTabButton>
+            </div>
+            <ChevronDown className={`ml-auto w-5 h-5 text-muted-foreground transition-transform ${open ? '' : 'rotate-180'}`} />
+          </div>
+
+          {/* Sheet body */}
+          <div className="flex-1 min-h-0 overflow-hidden">
+            {tab === 'inventory' && hasInventory ? (
+              <InventoryPanel className="h-full" engine={activeEngine} />
+            ) : (
+              <ValidationPanel className="h-full" engine={activeEngine} />
+            )}
+          </div>
+        </div>
+      )}
+
+      {hasTutorial && (
+        <HtmlSandboxModal open={showTutorial} onOpenChange={setShowTutorial} title="Tutorial" html={puzzle.tutorial_html} />
+      )}
+      {hasHint && (
+        <HtmlSandboxModal open={showHint} onOpenChange={setShowHint} title="Hint" html={puzzle.clue_html} />
+      )}
+    </div>
+  );
+}
+
+function OverlayButton({ children, label, onClick }: { children: React.ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className="h-10 w-10 inline-flex items-center justify-center rounded-full bg-black/55 backdrop-blur-sm border border-white/15 text-white/90 active:scale-95 transition-transform"
+    >
+      {children}
+    </button>
+  );
+}
+
+function SheetTabButton({ children, active, onClick }: { children: React.ReactNode; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-9 px-3 inline-flex items-center gap-1.5 rounded-lg text-xs font-medium transition-colors ${
+        active ? 'bg-primary/15 text-primary border border-primary/30' : 'text-muted-foreground border border-transparent'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -243,6 +243,12 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
   // Show rotate button when an inventory piece is selected (for mobile users)
   const showRotateButton = !!selectedInventoryPiece || !!selectedPlacedPiece;
 
+  // On compact UIs the touch control bar sits in a reserved strip at the bottom
+  // (via container padding) so it never overlaps — and block — board cells.
+  // The ResizeObserver measures the content box (excludes padding), so the
+  // board automatically re-fits into the space above the bar.
+  const showTouchControls = compact && showRotateButton;
+
   if (!puzzle) {
     return (
       <div className="w-full h-full flex items-center justify-center bg-editor-bg">
@@ -252,7 +258,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
   }
 
   return (
-    <div ref={containerRef} className={`relative w-full h-full flex items-center justify-center ${className}`} style={{ background: C.background }}>
+    <div ref={containerRef} className={`relative w-full h-full flex items-center justify-center ${showTouchControls ? 'pb-20' : ''} ${className}`} style={{ background: C.background }}>
       <svg
         ref={svgRef}
         width="100%"
@@ -505,8 +511,9 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
       </svg>
 
       {/* Touch control bar \u2014 replaces keyboard R / Delete / Esc on phones.
-          Shown when a piece or inventory tile is selected. */}
-      {compact && (selectedInventoryPiece || selectedPlacedPiece) && (
+          Lives in the reserved bottom strip (container pb-20) so it never
+          covers tappable board cells. */}
+      {showTouchControls && (
         <div className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 flex items-center gap-2 px-2 py-1.5 rounded-full bg-black/70 backdrop-blur-sm border border-white/15 shadow-lg">
           {/* Slider puzzles don't rotate (and removing a pre-placed block would
               soft-lock the puzzle), so only show Done for them. */}

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -12,6 +12,8 @@ import type { UsePuzzleEngineReturn } from '../../engine';
 import { getValidSlideDestinations, findPiecesStackedOnTop, getPieceCells } from '../../engine';
 import { SCENE_2D } from '../../config/sceneConfig';
 import { useRuleBuilderStore } from '../editor/ruleBuilder/useRuleBuilderStore';
+import { useIsTouch, useIsMobile } from '../../hooks/useMediaQuery';
+import { RotateCw, Trash2, Check } from 'lucide-react';
 
 import {
   SvgDefs,
@@ -46,7 +48,12 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
   const isPickerActive = useRuleBuilderStore(s => s.cellPickerTarget !== null);
   const pickerCells = useRuleBuilderStore(s => s.cellPickerCells);
 
+  // "compact" = a touch device OR a phone-width viewport. In either case we
+  // show the on-screen control bar (rotate/remove/done) and hide the SVG
+  // rotate button + keyboard-only affordances.
+  const compact = useIsTouch() || useIsMobile();
   const containerRef = useRef<HTMLDivElement>(null);
+  const boardGroupRef = useRef<SVGGElement>(null);
   const [containerSize, setContainerSize] = useState<{ w: number; h: number } | null>(null);
 
   // Observe container size for dynamic cell sizing
@@ -147,6 +154,31 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
     return vbW > 0 && rect.width > 0 ? rect.width / vbW : 1;
   }, []);
 
+  // Map a client (screen) coordinate to a board cell using the board group's
+  // own screen CTM. This is the source of truth for the drop target during a
+  // drag — on touch the pointer is implicitly captured to the press target, so
+  // per-cell pointerenter/leave never fire on the cells a finger slides over
+  // and `hoveredCell` would otherwise stay stale/null. Computing the cell from
+  // the pointer position works for both mouse and touch.
+  const cellFromClient = useCallback(
+    (clientX: number, clientY: number): { x: number; y: number } | null => {
+      const g = boardGroupRef.current;
+      const svg = svgRef.current;
+      if (!g || !svg) return null;
+      const ctm = g.getScreenCTM();
+      if (!ctm) return null;
+      const pt = svg.createSVGPoint();
+      pt.x = clientX;
+      pt.y = clientY;
+      const local = pt.matrixTransform(ctm.inverse());
+      const cx = Math.floor(local.x / cellSize);
+      const cy = Math.floor(local.y / cellSize);
+      if (cx < 0 || cx >= width || cy < 0 || cy >= height) return null;
+      return { x: cx, y: cy };
+    },
+    [cellSize, width, height],
+  );
+
   // Clear drag visual on any pointer release anywhere — even outside the
   // SVG — so the piece doesn't get stuck mid-translate if the user
   // releases off-board.
@@ -220,7 +252,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
   }
 
   return (
-    <div ref={containerRef} className={`w-full h-full flex items-center justify-center ${className}`} style={{ background: C.background }}>
+    <div ref={containerRef} className={`relative w-full h-full flex items-center justify-center ${className}`} style={{ background: C.background }}>
       <svg
         ref={svgRef}
         width="100%"
@@ -256,6 +288,7 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
 
         {/* Main board area */}
         <g
+          ref={boardGroupRef}
           transform={`translate(${PADDING + hintsLeftWidth}, ${PADDING + hintsTopHeight})`}
           onPointerDown={dragNdrop ? (e) => {
             dragStartRef.current = { x: e.clientX, y: e.clientY, pointerId: e.pointerId };
@@ -273,6 +306,9 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
               dx: (e.clientX - start.x) / scale,
               dy: (e.clientY - start.y) / scale,
             });
+            // Track the drop target from the pointer position so the ghost
+            // and commit work on touch (where pointerenter never fires).
+            setHoveredCell(cellFromClient(e.clientX, e.clientY));
           } : undefined}
           onPointerUp={dragNdrop ? (e) => {
             const start = dragStartRef.current;
@@ -295,8 +331,11 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
               const moved = Math.sqrt(dx * dx + dy * dy) >= DRAG_THRESHOLD_PX;
               if (!moved) return; // simple tap — selection only, no commit
             }
-            if (!hoveredCell) return; // released off-board
-            handleCellPointerUp(hoveredCell.x, hoveredCell.y);
+            // Resolve the target cell from the release coordinate (robust on
+            // touch); fall back to the last hovered cell for mouse.
+            const cell = cellFromClient(e.clientX, e.clientY) ?? hoveredCell;
+            if (!cell) return; // released off-board
+            handleCellPointerUp(cell.x, cell.y);
           } : undefined}
         >
           {/* Board background with gradient and shadow */}
@@ -420,8 +459,8 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
             />
           )}
 
-          {/* On-screen rotate button (for mobile users) */}
-          {showRotateButton && (
+          {/* On-screen rotate button (desktop mouse only — compact UI uses the HTML control bar) */}
+          {showRotateButton && !compact && (
             <g
               transform={`translate(${width * cellSize - 36}, ${height * cellSize - 36})`}
               onPointerDown={(e) => { e.stopPropagation(); handleRotate(); }}
@@ -464,6 +503,48 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
           {puzzle.goal && ' \u2022 Slider Puzzle'}
         </text>
       </svg>
+
+      {/* Touch control bar \u2014 replaces keyboard R / Delete / Esc on phones.
+          Shown when a piece or inventory tile is selected. */}
+      {compact && (selectedInventoryPiece || selectedPlacedPiece) && (
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 flex items-center gap-2 px-2 py-1.5 rounded-full bg-black/70 backdrop-blur-sm border border-white/15 shadow-lg">
+          {/* Slider puzzles don't rotate (and removing a pre-placed block would
+              soft-lock the puzzle), so only show Done for them. */}
+          {!isSliderPuzzle && (
+            <button
+              type="button"
+              aria-label="Rotate piece"
+              className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-white/90 text-xs font-medium active:scale-95 transition-transform"
+              onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); handleRotate(); }}
+            >
+              <RotateCw className="w-5 h-5" /> Rotate
+            </button>
+          )}
+          {selectedPlacedPiece && !isSliderPuzzle && (
+            <button
+              type="button"
+              aria-label="Remove piece"
+              className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-red-300 text-xs font-medium active:scale-95 transition-transform"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                engine.removePiece(selectedPlacedPiece.instanceId);
+                engine.selectPiece(null);
+              }}
+            >
+              <Trash2 className="w-5 h-5" /> Remove
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Done"
+            className="h-11 px-3 inline-flex items-center gap-1.5 rounded-full text-white/90 text-xs font-medium active:scale-95 transition-transform"
+            onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); engine.selectPiece(null); }}
+          >
+            <Check className="w-5 h-5" /> Done
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/renderer/Renderer2D.tsx
+++ b/src/components/renderer/Renderer2D.tsx
@@ -50,8 +50,11 @@ export function Renderer2D({ engine, className = '' }: Renderer2DProps) {
 
   // "compact" = a touch device OR a phone-width viewport. In either case we
   // show the on-screen control bar (rotate/remove/done) and hide the SVG
-  // rotate button + keyboard-only affordances.
-  const compact = useIsTouch() || useIsMobile();
+  // rotate button + keyboard-only affordances. Both hooks are called
+  // unconditionally (no `||` short-circuit) to satisfy the rules of hooks.
+  const isTouch = useIsTouch();
+  const isMobile = useIsMobile();
+  const compact = isTouch || isMobile;
   const containerRef = useRef<HTMLDivElement>(null);
   const boardGroupRef = useRef<SVGGElement>(null);
   const [containerSize, setContainerSize] = useState<{ w: number; h: number } | null>(null);

--- a/src/components/ui/ChatPanel.tsx
+++ b/src/components/ui/ChatPanel.tsx
@@ -16,6 +16,7 @@ import { usePuzzleStore } from '../../store/puzzleStore';
 import { ArrowUp, X, Plus, Lightbulb, ClipboardCheck, ChartBar, Zap, WandSparkles, GripHorizontal } from 'lucide-react';
 import { Button } from '../ui/shadcn/button';
 import { LegoHelperIcon } from './LegoHelperIcon';
+import { useIsMobile } from '../../hooks/useMediaQuery';
 
 // Re-export for backward compatibility
 export { LegoHelperIcon };
@@ -34,21 +35,6 @@ interface ChatPanelProps {
 function isRTL(text: string) {
   const rtlRegex = /[\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC]/;
   return rtlRegex.test(text);
-}
-
-/** Hook to detect mobile viewport (<768px) */
-function useIsMobile(breakpoint = 768) {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
-  );
-  useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    setIsMobile(mq.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, [breakpoint]);
-  return isMobile;
 }
 
 const PANEL_WIDTH = 420;

--- a/src/components/ui/CongratulationsPopup.tsx
+++ b/src/components/ui/CongratulationsPopup.tsx
@@ -122,7 +122,7 @@ export function CongratulationsPopup({
   return (
     <Dialog open={isVisible} onOpenChange={(open) => !open && onClose()}>
       <DialogContent
-        className="celebration-dialog max-w-sm p-0 gap-0 border-none overflow-visible bg-transparent shadow-none"
+        className="celebration-dialog mx-4 w-full max-w-[calc(100vw-2rem)] sm:max-w-sm p-0 gap-0 border-none overflow-visible bg-transparent shadow-none"
         showCloseButton={false}
       >
         {/* ── Full-viewport confetti layer ── */}
@@ -274,10 +274,12 @@ export function CongratulationsPopup({
 
           {/* Corner Lego studs (bigger, with inner ring for realism) */}
           {[
-            { pos: '-top-3.5 -left-3.5', color: 'bg-lego-red' },
-            { pos: '-top-3.5 -right-3.5', color: 'bg-lego-blue' },
-            { pos: '-bottom-3.5 -left-3.5', color: 'bg-lego-yellow' },
-            { pos: '-bottom-3.5 -right-3.5', color: 'bg-lego-green' },
+            // Smaller negative offsets at <sm so the studs don't clip past the
+            // viewport edge on narrow phones; full pop-out on sm+.
+            { pos: 'top-0 left-0 sm:-top-3.5 sm:-left-3.5', color: 'bg-lego-red' },
+            { pos: 'top-0 right-0 sm:-top-3.5 sm:-right-3.5', color: 'bg-lego-blue' },
+            { pos: 'bottom-0 left-0 sm:-bottom-3.5 sm:-left-3.5', color: 'bg-lego-yellow' },
+            { pos: 'bottom-0 right-0 sm:-bottom-3.5 sm:-right-3.5', color: 'bg-lego-green' },
           ].map(({ pos, color }, i) => (
             <div key={i} className={`absolute ${pos} w-8 h-8 ${color} rounded-full border-2 border-background shadow-lg ${prefersReducedMotion ? '' : 'celebration-corner-stud'}`} style={prefersReducedMotion ? undefined : { animationDelay: `${0.6 + i * 0.1}s` }}>
               <div className="absolute inset-1.5 rounded-full border border-white/20" />

--- a/src/components/ui/HtmlSandboxModal.tsx
+++ b/src/components/ui/HtmlSandboxModal.tsx
@@ -27,19 +27,21 @@ export function HtmlSandboxModal({ open, onOpenChange, title, html }: HtmlSandbo
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton
-        className="!max-w-[720px] !w-[720px] gap-3 p-4"
-        style={{ height: 520 }}
+        // Responsive sizing: full-width up to a 720px cap on desktop, and a
+        // height that shrinks to fit phone viewports (min of 80dvh / 520px).
+        // The grid layout lets the iframe flex to fill the remaining space.
+        className="w-full sm:max-w-[720px] gap-3 p-4 grid-rows-[auto_1fr]"
+        style={{ height: 'min(80dvh, 520px)' }}
       >
         <DialogTitle className="text-base">{title}</DialogTitle>
         <iframe
           title={title}
           srcDoc={html}
           sandbox=""
-          // Hardcoded dimensions — `sandbox=""` already blocks scripts,
-          // and the explicit width/height means CSS inside the iframe
-          // can't grow the frame itself.
-          className="w-full rounded-lg border border-border bg-background"
-          style={{ height: 440 }}
+          // `sandbox=""` already blocks scripts; the iframe fills the
+          // dialog's flexible content row so it scales with the viewport
+          // without letting CSS inside grow the frame itself.
+          className="w-full h-full min-h-0 rounded-lg border border-border bg-background"
         />
       </DialogContent>
     </Dialog>

--- a/src/components/ui/InstructionsModal.tsx
+++ b/src/components/ui/InstructionsModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useIsTouch } from '../../hooks/useMediaQuery';
 import {
   Dialog,
   DialogContent,
@@ -48,6 +49,7 @@ function KBD({ children }: { children: React.ReactNode }) {
 
 function CopyableCode({ children }: { children: string }) {
   const [copied, setCopied] = useState(false);
+  const isTouch = useIsTouch();
 
   const handleCopy = () => {
     navigator.clipboard.writeText(children);
@@ -62,7 +64,7 @@ function CopyableCode({ children }: { children: string }) {
       </pre>
       <button
         onClick={handleCopy}
-        className="absolute top-2 right-2 p-1.5 rounded-md bg-secondary/80 border border-[var(--border-subtle)] text-muted-foreground hover:text-foreground hover:bg-secondary transition-all opacity-0 group-hover:opacity-100 cursor-pointer"
+        className={`absolute top-2 right-2 p-1.5 rounded-md bg-secondary/80 border border-[var(--border-subtle)] text-muted-foreground hover:text-foreground hover:bg-secondary transition-all group-hover:opacity-100 cursor-pointer ${isTouch ? 'opacity-100' : 'opacity-0'}`}
         aria-label="Copy code"
       >
         {copied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
@@ -372,6 +374,7 @@ function ShapesTab() {
 }
 
 function ValidationTab() {
+  const isTouch = useIsTouch();
   const rules = [
     { name: 'ALL_BOARD_SQUARES_MUST_BE_COVERED', type: 'COVERAGE', desc: 'Every cell on the board must be covered by a brick. Used for classic coverage puzzles.' },
     { name: 'ALL_BRICKS_MUST_BE_USED', type: 'COUNT', desc: 'All bricks from the inventory must be placed on the board. Board can have empty cells.' },
@@ -447,19 +450,35 @@ function ValidationTab() {
             <code className="text-primary text-sm">{rule.name}</code>
             <p className="text-muted-foreground text-sm mt-1">{rule.desc}</p>
             {rule.paramDetails && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                <span className="text-muted-foreground text-xs">Params:</span>
-                {rule.paramDetails.map((param, idx) => (
-                  <span key={idx} className="relative group">
-                    <code className="text-cyan-400 text-xs cursor-help px-1.5 py-0.5 bg-cyan-500/10 rounded hover:bg-cyan-500/20 transition-colors">
-                      {param.name}
-                    </code>
-                    <span className="absolute left-0 bottom-full mb-2 w-64 p-2 bg-popover border border-border rounded-lg text-xs text-popover-foreground opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 shadow-xl">
-                      {param.tooltip}
+              isTouch ? (
+                // Touch: hover popovers never reveal, so show each param's
+                // description inline (always visible) instead.
+                <div className="mt-2 space-y-1">
+                  <span className="text-muted-foreground text-xs">Params:</span>
+                  {rule.paramDetails.map((param, idx) => (
+                    <div key={idx} className="flex gap-2">
+                      <code className="text-cyan-400 text-xs shrink-0 px-1.5 py-0.5 bg-cyan-500/10 rounded">
+                        {param.name}
+                      </code>
+                      <span className="text-muted-foreground text-xs">{param.tooltip}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <span className="text-muted-foreground text-xs">Params:</span>
+                  {rule.paramDetails.map((param, idx) => (
+                    <span key={idx} className="relative group">
+                      <code className="text-cyan-400 text-xs cursor-help px-1.5 py-0.5 bg-cyan-500/10 rounded hover:bg-cyan-500/20 transition-colors">
+                        {param.name}
+                      </code>
+                      <span className="absolute left-0 bottom-full mb-2 w-64 p-2 bg-popover border border-border rounded-lg text-xs text-popover-foreground opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50 shadow-xl">
+                        {param.tooltip}
+                      </span>
                     </span>
-                  </span>
-                ))}
-              </div>
+                  ))}
+                </div>
+              )
             )}
           </div>
         ))}
@@ -1131,7 +1150,10 @@ export function InstructionsModal({ isOpen, onClose }: InstructionsModalProps) {
           </div>
         </Tabs>
 
-        <DialogFooter className="px-6 py-4 border-t border-border flex-shrink-0">
+        <DialogFooter
+          className="px-6 py-4 pb-safe-bottom border-t border-border flex-shrink-0"
+          style={{ '--pb-extra': '1rem' } as React.CSSProperties}
+        >
           <Button onClick={onClose}>Got it!</Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/ui/KeyboardShortcutsOverlay.tsx
+++ b/src/components/ui/KeyboardShortcutsOverlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useIsTouch } from '../../hooks/useMediaQuery';
 
 const SHORTCUTS = [
   { keys: ['R'], description: 'Rotate selected brick' },
@@ -12,8 +13,12 @@ const SHORTCUTS = [
 
 export function KeyboardShortcutsOverlay() {
   const [isVisible, setIsVisible] = useState(false);
+  // Keyboard/mouse-only shortcuts are meaningless on touch devices — never
+  // wire up the listener or render the overlay there.
+  const isTouch = useIsTouch();
 
   useEffect(() => {
+    if (isTouch) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable) return;
@@ -27,9 +32,9 @@ export function KeyboardShortcutsOverlay() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isVisible]);
+  }, [isVisible, isTouch]);
 
-  if (!isVisible) return null;
+  if (isTouch || !isVisible) return null;
 
   return (
     <div

--- a/src/components/ui/PuzzleInfoPopup.tsx
+++ b/src/components/ui/PuzzleInfoPopup.tsx
@@ -7,6 +7,7 @@ import {
   MousePointerClick, RotateCw, Trash2, Move, Grid3X3, ChevronDown,
 } from 'lucide-react';
 import type { UsePuzzleEngineReturn } from '../../engine';
+import { useIsMobile } from '../../hooks/useMediaQuery';
 
 const FRIENDLY_RULES: Record<string, { label: string; desc: string }> = {
   'ALL_BOARD_SQUARES_MUST_BE_COVERED': { label: 'Full Coverage', desc: 'Every cell on the board must be covered by a brick' },
@@ -39,6 +40,7 @@ interface PuzzleInfoPopupProps {
 export function PuzzleInfoPopup({ isOpen, onClose, engine }: PuzzleInfoPopupProps) {
   const store = usePuzzleStore(useShallow(s => ({ puzzle: s.puzzle })));
   const puzzle = engine?.puzzle ?? store.puzzle;
+  const isMobile = useIsMobile();
 
   const [size, setSize] = useState({ w: 420, h: 520 });
   const [pos, setPos] = useState(() => ({
@@ -103,19 +105,27 @@ export function PuzzleInfoPopup({ isOpen, onClose, engine }: PuzzleInfoPopupProp
   return (
     <div
       ref={popupRef}
-      className="fixed z-[45] rounded-2xl border border-border/80 bg-card/95 backdrop-blur-xl shadow-2xl shadow-black/50 flex flex-col overflow-hidden cursor-move"
-      style={{
-        left: pos.x, top: pos.y,
-        width: minimized ? 300 : size.w,
-        height: minimized ? 'auto' : size.h,
-      }}
-      onPointerDown={onDragStart}
-      onPointerMove={onDragMove}
-      onPointerUp={onDragEnd}
+      className={
+        isMobile
+          ? 'fixed z-[45] left-0 right-0 bottom-0 w-full rounded-t-2xl border-t border-border/80 bg-card/95 backdrop-blur-xl shadow-2xl shadow-black/50 flex flex-col overflow-hidden pb-safe'
+          : 'fixed z-[45] rounded-2xl border border-border/80 bg-card/95 backdrop-blur-xl shadow-2xl shadow-black/50 flex flex-col overflow-hidden cursor-move'
+      }
+      style={
+        isMobile
+          ? { maxHeight: '85dvh' }
+          : {
+              left: pos.x, top: pos.y,
+              width: minimized ? 300 : size.w,
+              height: minimized ? 'auto' : size.h,
+            }
+      }
+      onPointerDown={isMobile ? undefined : onDragStart}
+      onPointerMove={isMobile ? undefined : onDragMove}
+      onPointerUp={isMobile ? undefined : onDragEnd}
     >
       {/* ── Title Bar ── */}
       <div className="flex items-center gap-2.5 px-4 py-2.5 bg-gradient-to-r from-[var(--surface-raised)] to-card border-b border-border select-none shrink-0">
-        <GripHorizontal className="w-4 h-4 text-muted-foreground/50 shrink-0" />
+        {!isMobile && <GripHorizontal className="w-4 h-4 text-muted-foreground/50 shrink-0" />}
         <BookOpen className="w-4 h-4 text-primary shrink-0" />
         <span className="text-sm font-bold text-foreground flex-1 truncate">Rules & Controls</span>
         <div className="flex items-center gap-1.5">
@@ -126,11 +136,22 @@ export function PuzzleInfoPopup({ isOpen, onClose, engine }: PuzzleInfoPopupProp
             {puzzle.viewMode}
           </Badge>
         </div>
-        <button onPointerDown={e => e.stopPropagation()} onClick={() => setMinimized(!minimized)} className="p-1.5 rounded-lg hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors">
-          <Minus className="w-3.5 h-3.5" />
-        </button>
-        <button onPointerDown={e => e.stopPropagation()} onClick={onClose} className="p-1.5 rounded-lg hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors">
-          <X className="w-3.5 h-3.5" />
+        {!isMobile && (
+          <button onPointerDown={e => e.stopPropagation()} onClick={() => setMinimized(!minimized)} className="p-1.5 rounded-lg hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors">
+            <Minus className="w-3.5 h-3.5" />
+          </button>
+        )}
+        <button
+          onPointerDown={e => e.stopPropagation()}
+          onClick={onClose}
+          aria-label="Close"
+          className={
+            isMobile
+              ? 'flex items-center justify-center w-10 h-10 -mr-1.5 rounded-lg hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors'
+              : 'p-1.5 rounded-lg hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-colors'
+          }
+        >
+          <X className={isMobile ? 'w-5 h-5' : 'w-3.5 h-3.5'} />
         </button>
       </div>
 
@@ -244,8 +265,8 @@ export function PuzzleInfoPopup({ isOpen, onClose, engine }: PuzzleInfoPopupProp
         </div>
       )}
 
-      {/* ── Resize Handle ── */}
-      {!minimized && (
+      {/* ── Resize Handle (desktop only) ── */}
+      {!isMobile && !minimized && (
         <div
           className="absolute bottom-0 right-0 w-5 h-5 cursor-nwse-resize group"
           onPointerDown={onResizeStart}

--- a/src/components/ui/XPBar.tsx
+++ b/src/components/ui/XPBar.tsx
@@ -1,4 +1,5 @@
 import { useUserStore } from '../../store/userStore';
+import { useIsTouch } from '../../hooks/useMediaQuery';
 import {
   Tooltip,
   TooltipContent,
@@ -9,6 +10,7 @@ export function XPBar({ compact = false }: { compact?: boolean }) {
   const profile = useUserStore((s) => s.profile);
   const levelTitle = useUserStore((s) => s.levelTitle);
   const levelProgress = useUserStore((s) => s.levelProgress);
+  const isTouch = useIsTouch();
 
   if (!profile) return null;
 
@@ -26,28 +28,43 @@ export function XPBar({ compact = false }: { compact?: boolean }) {
     );
   }
 
+  const bar = (
+    <div className="flex items-center gap-2 px-2 py-1 rounded-lg bg-secondary/50 border border-border cursor-default">
+      {/* Level badge */}
+      <span className="text-xs font-bold text-primary min-w-[2ch] text-center">
+        {profile.level}
+      </span>
+
+      {/* Progress bar */}
+      <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">
+        <div
+          className="h-full rounded-full bg-primary transition-all duration-500"
+          style={{ width: `${Math.min(100, levelProgress * 100)}%` }}
+        />
+      </div>
+
+      {/* XP label */}
+      <span className="text-[10px] text-muted-foreground font-medium">
+        {profile.xp.toLocaleString()}
+      </span>
+
+      {/* Level title — inline on touch (no hover tooltip available) */}
+      {isTouch && (
+        <span className="text-[10px] text-foreground/80 font-medium border-l border-border pl-2">
+          {levelTitle}
+        </span>
+      )}
+    </div>
+  );
+
+  // On touch devices the hover tooltip never opens, so the level title is shown
+  // inline above and we skip the tooltip wrapper entirely.
+  if (isTouch) return bar;
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div className="flex items-center gap-2 px-2 py-1 rounded-lg bg-secondary/50 border border-border cursor-default">
-          {/* Level badge */}
-          <span className="text-xs font-bold text-primary min-w-[2ch] text-center">
-            {profile.level}
-          </span>
-
-          {/* Progress bar */}
-          <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">
-            <div
-              className="h-full rounded-full bg-primary transition-all duration-500"
-              style={{ width: `${Math.min(100, levelProgress * 100)}%` }}
-            />
-          </div>
-
-          {/* XP label */}
-          <span className="text-[10px] text-muted-foreground font-medium">
-            {profile.xp.toLocaleString()}
-          </span>
-        </div>
+        {bar}
       </TooltipTrigger>
       <TooltipContent>
         <p className="font-medium">{levelTitle}</p>

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] shadow-lg duration-200 outline-none sm:max-w-lg",
           className
         )}
         {...props}
@@ -68,7 +68,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 flex items-center justify-center rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [@media(pointer:coarse)]:-m-2 [@media(pointer:coarse)]:p-2"
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/src/config/puzzleCategories.ts
+++ b/src/config/puzzleCategories.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_PUZZLE, FIT_ALL_PUZZLE, BLANK_PUZZLE, SLIDER_PUZZLE, GRID_PUZZLE, BINARY_PUZZLE, BINARY_PUZZLE_SOS, BINARY_PUZZLE_BUILDING_BLOCKS, COLORFUL_COVERAGE_PUZZLE } from '../types/puzzle';
 import { KLOTSKI_RED_DONKEY, KLOTSKI_CROSSWAY, PEN_CHALLENGE_PUZZLE, NONOGRAM_PUZZLE, NONOGRAM_PUZZLE_2 } from '../types/puzzle';
-import { RUBIKS_CUBE_PUZZLE, ACYCLIC_SHADOWS_PUZZLE } from '../data/puzzles';
+import { RUBIKS_CUBE_PUZZLE } from '../data/puzzles';
 import type { LucideIcon } from 'lucide-react';
 import { Grid3x3, LayoutGrid, Move, Binary, Lightbulb, Brain, Box } from 'lucide-react';
 
@@ -80,7 +80,6 @@ export const PUZZLE_CATEGORIES: PuzzleCategory[] = [
     icon: Box,
     puzzles: [
       { id: 'rubiks-cube', label: "Rubik's Cube", puzzle: RUBIKS_CUBE_PUZZLE, is3D: true },
-      { id: 'acyclic-shadows', label: 'Acyclic Shadows', puzzle: ACYCLIC_SHADOWS_PUZZLE, is3D: true },
     ],
   },
 ];

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Reactive matchMedia hook. Returns whether the given media query currently
+ * matches, updating on change (orientation, resize, devtools toggle).
+ *
+ * SSR-safe: returns `false` when `window` is unavailable.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    // Sync immediately in case the query changed between render and effect.
+    setMatches(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+/**
+ * The single source of truth for "is this a phone-sized viewport".
+ *
+ * Standardised on the Tailwind `md` breakpoint (768px): below it we render the
+ * dedicated mobile layouts (bottom-sheet inventory, stacked editor, bottom nav).
+ * Use this everywhere instead of ad-hoc `window.innerWidth` reads.
+ */
+export const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(breakpoint: number = MOBILE_BREAKPOINT): boolean {
+  return useMediaQuery(`(max-width: ${breakpoint - 1}px)`);
+}
+
+/**
+ * Whether the primary pointer is coarse (finger / stylus) rather than a mouse.
+ *
+ * This is orthogonal to viewport size — a small laptop window is NOT coarse, and
+ * a large tablet IS. Use it to gate touch-only affordances (on-screen rotate /
+ * delete controls, always-visible card actions) so they appear for real touch
+ * devices regardless of width, and stay hidden for mouse users.
+ */
+export function useIsTouch(): boolean {
+  return useMediaQuery('(pointer: coarse)');
+}

--- a/src/index.css
+++ b/src/index.css
@@ -170,10 +170,38 @@
 }
 
 /* ─── Global ─── */
-html, body, #root {
+html, body {
   width: 100%;
   height: 100%;
   overflow: hidden;
+}
+#root {
+  width: 100%;
+  /* Dynamic viewport height: on mobile, 100vh includes the area under the
+     URL bar / bottom toolbar, clipping bottom-pinned UI. 100dvh tracks the
+     actual visible viewport. vh is kept as a fallback for old browsers. */
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+/* ─── Safe-area helpers (notches / home indicator; needs viewport-fit=cover) ─── */
+.pt-safe { padding-top: env(safe-area-inset-top); }
+.pb-safe { padding-bottom: env(safe-area-inset-bottom); }
+.pl-safe { padding-left: env(safe-area-inset-left); }
+.pr-safe { padding-right: env(safe-area-inset-right); }
+.mb-safe { margin-bottom: env(safe-area-inset-bottom); }
+/* Add the bottom inset on TOP of existing padding for bottom-pinned bars. */
+.pb-safe-bottom { padding-bottom: calc(env(safe-area-inset-bottom) + var(--pb-extra, 0px)); }
+
+/* On touch devices the decorative draggable bricks must not eat scroll/taps
+   over real content. Disable their pointer interaction on coarse pointers. */
+@media (pointer: coarse) {
+  .lego-bg-brick-interactive {
+    pointer-events: none !important;
+    touch-action: auto !important;
+    cursor: default !important;
+  }
 }
 
 /* ─── Animated Lego Background ─── */

--- a/src/runtime/plugin/examples/acyclicShadowsPlugin.ts
+++ b/src/runtime/plugin/examples/acyclicShadowsPlugin.ts
@@ -396,7 +396,7 @@ const ACYCLIC = (function () {
     function mkBtn(label, fn) {
       var b = document.createElement("button");
       b.textContent = label;
-      b.style.cssText = "padding:6px 10px;font-size:12px;font-weight:600;color:#e8e8ea;background:#262a33;border:1px solid #3a3f4b;border-radius:6px;cursor:pointer";
+      b.style.cssText = "padding:9px 13px;min-height:40px;font-size:14px;font-weight:600;color:#e8e8ea;background:#262a33;border:1px solid #3a3f4b;border-radius:8px;cursor:pointer;touch-action:manipulation";
       b.onmouseenter = function () { b.style.background = "#30353f"; };
       b.onmouseleave = function () { b.style.background = "#262a33"; };
       b.onclick = fn; bar.appendChild(b); return b;
@@ -429,7 +429,12 @@ const ACYCLIC = (function () {
     // orbit (drag) + pick (click). A small movement threshold separates the two.
     var dragging = false, moved = 0, lx = 0, ly = 0, pinch = 0;
     var raycaster = new THREE.Raycaster(), ndc = new THREE.Vector2();
-    function pt(e) { return e.touches && e.touches[0] ? e.touches[0] : e; }
+    // On touchend, e.touches is empty — the released point lives in
+    // changedTouches. Without this, tap-to-toggle reads undefined coords and
+    // silently fails on touch.
+    function pt(e) {
+      return (e.touches && e.touches[0]) || (e.changedTouches && e.changedTouches[0]) || e;
+    }
     function touchDist(e) {
       var a = e.touches[0], b = e.touches[1];
       var dx = a.clientX - b.clientX, dy = a.clientY - b.clientY;
@@ -459,7 +464,8 @@ const ACYCLIC = (function () {
       lx = p.clientX; ly = p.clientY; invalidate();
     }
     function up(e) {
-      if (dragging && moved < 6) pick(e);
+      // Slightly looser tap threshold for touch (fingers jitter more than a mouse).
+      if (dragging && moved < 10) pick(e);
       dragging = false; pinch = 0; renderer.domElement.style.cursor = "grab";
     }
     function onWheel(e) { e.preventDefault(); zoomBy(e.deltaY > 0 ? 1.1 : 0.9); }

--- a/src/runtime/plugin/examples/rubiksCubePlugin.ts
+++ b/src/runtime/plugin/examples/rubiksCubePlugin.ts
@@ -279,7 +279,7 @@ const CUBE = (function () {
     function mkBtn(label, f, d) {
       var b = document.createElement("button");
       b.textContent = label;
-      b.style.cssText = "padding:6px 10px;font-size:13px;font-weight:600;color:#e8e8ea;background:#262a33;border:1px solid #3a3f4b;border-radius:6px;cursor:pointer;min-width:36px";
+      b.style.cssText = "padding:9px 12px;font-size:15px;font-weight:600;color:#e8e8ea;background:#262a33;border:1px solid #3a3f4b;border-radius:8px;cursor:pointer;min-width:44px;min-height:44px;touch-action:manipulation";
       b.onmouseenter = function () { b.style.background = "#30353f"; };
       b.onmouseleave = function () { b.style.background = "#262a33"; };
       b.onclick = function () { api.emitMove({ face: f, dir: d }); };


### PR DESCRIPTION
Makes the whole site usable on phones with mobile-specific layouts, and fixes the underlying touch interactions so **every puzzle type is solvable** at any screen size — not just visually rescaled.

## Why
Audit found several puzzles were *unsolvable* on touch (not merely cramped): 2D drag-placement landed on the wrong cell (per-cell `pointerenter` doesn't fire during a captured touch drag), 3D rotate/remove were keyboard/right-click/double-click only, and the editor was hard-gated off mobile.

## Foundation
- Shared reactive hooks (`useMediaQuery` / `useIsMobile(768)` / `useIsTouch`); replaces ChatPanel's private hook and PuzzleShell's inline width check. Standard breakpoint = `md` (768).
- `100dvh` root, `viewport-fit=cover` + safe-area utilities; draggable background bricks no longer hijack scroll/taps on touch.
- Bottom tab bar (`MobileNav`) replaces the desktop-only sidebar on phones.

## Puzzle player (`MobilePuzzlePlay`)
Full-bleed board + collapsible bottom-sheet inventory/validation + Tutorial/Hint/Rules overlay. Touch model: **tap a brick → tap a cell**.
- **2D:** resolve the drop target from pointer coords via `getScreenCTM().inverse()` (the real fix for touch placement); on-screen Rotate/Remove/Done.
- **3D:** on-screen Rotate/Remove/Done, pointer-up cell fallback, touch-aware drag threshold, `touch-action:none`, farther zoom-out for large/portrait boards. One-finger orbit + pinch-zoom already worked.
- **Plugins:** sandbox `touch-action:none` (stops page-scroll hijack); fix Acyclic-Shadows tap-toggle on `touchend` (`changedTouches`); larger control buttons.

## Editor on mobile (`MobileEditorTabs`)
Full-screen Board / JSON / Rules / Code tabs replace the desktop split. Monaco at 16px (no iOS zoom), `ConditionTypePicker` as a bottom sheet, cell-picker auto-switches to the Board tab, plus a mobile Edit entry point.

## Pages & modals
Mobile gallery sort, touch-visible card edit, wrapping Admin/MyPuzzles/Leaderboard/Profile rows, responsive `HtmlSandboxModal`, `PuzzleInfoPopup` bottom sheet, keyboard-shortcut overlay hidden on touch, hover-only reveals exposed on touch, safe-area padding.

## Verification
- `tsc -b` clean; `vite build` clean (only the pre-existing three.js/monaco chunk-size warning); lint shows only pre-existing warnings.
- Not yet tested on a physical device. Touch-only controls key off `pointer: coarse` — to verify: `npm run dev -- --host` and open the Network URL on a phone.

### Suggested device checklist
- 2D coverage/binary/nonogram: tap brick → tap cell; Rotate/Remove bar
- Slider/Klotski: tap piece → tap destination
- 3D coverage/fit-all: tap brick → tap cell; on-screen Rotate/Remove; pinch-zoom
- Rubik's: drag-orbit + face buttons
- Acyclic Shadows: orbit/pinch + tap edges
- No horizontal overflow on any page at ~360px