### PR TITLE
Fix chat 504 timeout and non-JSON error crash

### DIFF
--- a/api/[[...route]].ts
+++ b/api/[[...route]].ts
@@ -41,8 +41,14 @@ app.use('*', cors({
   allowHeaders: ['Content-Type', 'Authorization'],
 }));
 
-app.use('*', async (_c, next) => {
-  await connectDB();
+app.use('*', async (c, next) => {
+  // /chat is a pure proxy to the model API and never touches MongoDB. Skip the
+  // (potentially slow, cold-start) DB connect there so it can't consume the
+  // function's time budget — a cold Atlas connect can otherwise stall the request
+  // long enough to trip the function timeout before the model is even called.
+  if (!c.req.path.includes('/chat')) {
+    await connectDB();
+  }
   await next();
 });
 
@@ -828,6 +834,13 @@ app.post('/chat', async (c) => {
     parts: [{ text: m.content }],
   }));
 
+  // Abort the upstream model call before the platform hard-kills the function.
+  // Must stay strictly below the function maxDuration (vercel.json) so we can return
+  // clean JSON instead of letting Vercel emit a non-JSON gateway 504 page.
+  const timeoutMs = parseInt(process.env.CHAT_TIMEOUT_MS || '45000');
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+
   try {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
     const res = await fetch(url, {
@@ -843,6 +856,7 @@ app.post('/chat', async (c) => {
           temperature,
         },
       }),
+      signal: ac.signal,
     });
 
     if (!res.ok) {
@@ -869,10 +883,21 @@ app.post('/chat', async (c) => {
 
     return c.json({ success: true, message: content });
   } catch (error) {
+    // Our own AbortController fired — the model exceeded the budget. Return clean
+    // JSON 504 so the client shows a friendly message instead of crashing on a
+    // non-JSON platform error page.
+    if (error instanceof Error && error.name === 'AbortError') {
+      return c.json({
+        success: false,
+        error: 'The assistant took too long to respond. Please try again.',
+      }, 504);
+    }
     return c.json({
       success: false,
       error: error instanceof Error ? error.message : 'Chat service error',
     }, 500);
+  } finally {
+    clearTimeout(timer);
   }
 });
 

--- a/api/_lib/db.ts
+++ b/api/_lib/db.ts
@@ -27,7 +27,10 @@ export async function connectDB() {
 
     cached.promise = mongoose.connect(uri, {
       maxPoolSize: 2,
-      serverSelectionTimeoutMS: 15000,
+      // Keep server selection well inside the function time budget so a failed/cold
+      // connect surfaces as a catchable error (→ JSON 500) instead of hanging until
+      // the platform hard-kills the function and returns a non-JSON gateway page.
+      serverSelectionTimeoutMS: 10000,
     });
   }
 

--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -61,10 +61,24 @@ export async function sendChatMessage(
             body: JSON.stringify({ messages }),
         });
 
-        const data = await res.json();
+        // Read the body as text first. A gateway timeout (504) or other platform
+        // error returns a plain-text page (e.g. "An error occurred..."), and calling
+        // res.json() on that throws a confusing "Unexpected token 'A'..." SyntaxError.
+        // Parse defensively so non-JSON responses become a friendly message instead.
+        const raw = await res.text();
+        let data: { success?: boolean; message?: string; error?: string } = {};
+        try {
+            data = raw ? JSON.parse(raw) : {};
+        } catch {
+            // Non-JSON body (gateway/timeout page) — leave data empty and fall through.
+        }
 
         if (!res.ok) {
-            return { success: false, message: '', error: data.error || `API error: ${res.status}` };
+            const friendly =
+                res.status === 504 || res.status === 502 || res.status === 503
+                    ? 'The assistant took too long to respond. Please try again in a moment.'
+                    : data.error || `The assistant is temporarily unavailable (error ${res.status}).`;
+            return { success: false, message: '', error: friendly };
         }
 
         if (data.success && data.message) {
@@ -72,8 +86,8 @@ export async function sendChatMessage(
         }
 
         return { success: false, message: '', error: data.error || 'Empty response from chat service' };
-    } catch (error) {
-        return { success: false, message: '', error: error instanceof Error ? error.message : 'Chat service error' };
+    } catch {
+        return { success: false, message: '', error: 'Could not reach the chat service. Please try again.' };
     }
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "functions": {
     "api/[[...route]].ts": {
       "memory": 256,
-      "maxDuration": 10
+      "maxDuration": 60
     }
   },
   "crons": [


### PR DESCRIPTION
## Problem

Asking the in-app assistant a question frequently failed with two console errors that are actually **one event**:

- `POST /api/chat 504 (Gateway Timeout)`
- `Unexpected token 'A', "An error o"... is not valid JSON`

(The MetaMask `inpage.js` error in the same console is unrelated browser-extension noise.)

## Root cause

The catch-all API function is capped at `maxDuration: 10` seconds. Several latency sources stacked inside that budget on the `/chat` path:

1. **`connectDB()` ran on every request** (`app.use('*')`), including `/chat` — which never touches Mongo. On a cold MongoDB Atlas free-tier cluster, `serverSelectionTimeoutMS: 15000` alone exceeds the 10s function budget.
2. The handler made a **non-streaming** `generateContent` call to Google with **no timeout** — a large model generating up to 1000 tokens can take longer than 10s on its own.

When the wall clock hit 10s, Vercel killed the function and returned its **plain-text** error page (`"An error occurred..."`). The client called `res.json()` on that text **before** checking `res.ok`, so `JSON.parse` threw the `Unexpected token 'A'` `SyntaxError`, which was surfaced to the user verbatim.

## Changes

- **`src/services/ChatService.ts`** — Read the response body as text and parse it defensively before checking `res.ok`. Map 502/503/504 to a friendly message; stop leaking raw parser/network errors. This permanently kills the `Unexpected token 'A'` crash for any non-JSON 5xx/gateway body.
- **`api/[[...route]].ts` (middleware)** — Skip `connectDB()` for the `/chat` path so a cold DB connect can't consume the chat budget.
- **`api/[[...route]].ts` (chat handler)** — Abort the upstream model fetch via `AbortController` strictly below `maxDuration` (`CHAT_TIMEOUT_MS`, default 45s) and return clean JSON `504`, so the client always receives parseable JSON instead of a platform error page.
- **`api/_lib/db.ts`** — Lower `serverSelectionTimeoutMS` 15000 → 10000 so a failed/cold connect stays inside the function budget and surfaces as catchable JSON (affects all routes, since `connectDB` runs on `*`).
- **`vercel.json`** — Raise `maxDuration` 10 → 60 for model headroom. Note: this is the single catch-all function, so the bump is global.

## Verification

- Client (`src`) typechecks clean (`tsc --noEmit`).
- API typechecks with only one **pre-existing, unrelated** error (`puzzles/create` difficulty enum, present on `master`).
- ESLint: 0 errors on the touched files.

## Follow-ups (not in this PR)

- **Env tuning (no code change):** the default `CHAT_MODEL` is `gemma-4-31b-it` with 1000 max tokens. Setting `CHAT_MODEL` to a faster flash-class model and `CHAT_MAX_TOKENS` ≈ 512 in the Vercel dashboard would cut latency at the source. These read `process.env` first, so they must be changed in the dashboard, not in code.
- **SSE streaming** for the chat response — the most durable defense against gateway timeouts, but requires rewriting the buffering Node→Web transport handler (affects all routes); deferred.
- **`parseJsonSafe` sweep** — ~24 other `res.json()` callers share the same blind-parse pattern; worth routing through a shared helper in a later PR.
