### PR TITLE
Brighten puzzle viewport background (2D, 3D, plugin)

### DIFF
--- a/src/components/3d/PuzzleScene.tsx
+++ b/src/components/3d/PuzzleScene.tsx
@@ -1067,7 +1067,7 @@ function PuzzleSceneInner() {
   return (
     <div
       className={`w-full h-full relative transition-opacity duration-300 ${showTouchControls ? 'pb-20' : ''} ${sceneReady ? 'opacity-100' : 'opacity-0'}`}
-      style={{ cursor: shouldHideCursor ? 'none' : 'auto', backgroundColor: '#0f1520', touchAction: 'none' }}
+      style={{ cursor: shouldHideCursor ? 'none' : 'auto', backgroundColor: '#222a3a', touchAction: 'none' }}
       onContextMenu={(e) => {
         if (hasInventorySelection) {
           e.preventDefault();

--- a/src/config/sceneConfig.ts
+++ b/src/config/sceneConfig.ts
@@ -51,7 +51,7 @@ export const SCENE_3D = {
     point: { intensity: 0.18, position: [0, 6, 0] as const },
   },
 
-  fog: { color: '#0c111b', near: 30, far: 78 },
+  fog: { color: '#222a3a', near: 30, far: 78 },
 
   shadow: {
     mapSize: 2048 as number,
@@ -69,7 +69,11 @@ export const SCENE_3D = {
     far: 14,
   },
 
-  background: { color: '#0c111b', roughness: 0.95, metalness: 0.05 },
+  // Brighter medium-dark navy so the board/floor and (for plugin puzzles) the
+  // shadow walls read clearly — the previous '#0c111b' (oklch L≈0.18) was so
+  // dark the scene looked near-black. Drives the scene clear color, the floor
+  // grid plane, and (matched below) the fog. Kept on-theme "Night Baseplate".
+  background: { color: '#222a3a', roughness: 0.95, metalness: 0.05 },
 } as const;
 
 // ============================================

--- a/src/index.css
+++ b/src/index.css
@@ -397,11 +397,15 @@ html, body {
 /* A soft center spotlight over the stud-grid baseplate — the puzzle is the
    one bright object in the room. */
 .play-stage {
-  background-color: var(--surface-sunken);
+  /* Brighter "table" than the very dark --surface-sunken (oklch L≈0.09), which
+     left 2D boards and (transparent-canvas) plugin puzzles looking near-black.
+     Lifted to L≈0.24 with a stronger center spotlight so pieces/walls read,
+     while staying on-theme. Matches the 3D scene background brightness. */
+  background-color: oklch(0.24 0.024 250);
   background-image:
-    radial-gradient(circle at 1px 1px, oklch(1 0 0 / 0.022) 1.2px, transparent 1.3px),
-    radial-gradient(ellipse 70% 55% at 50% 42%, oklch(0.30 0.045 250 / 0.40), transparent 70%),
-    radial-gradient(ellipse at 50% 130%, oklch(0.05 0.01 250 / 0.9), transparent 55%);
+    radial-gradient(circle at 1px 1px, oklch(1 0 0 / 0.025) 1.2px, transparent 1.3px),
+    radial-gradient(ellipse 75% 60% at 50% 42%, oklch(0.42 0.05 250 / 0.45), transparent 72%),
+    radial-gradient(ellipse at 50% 130%, oklch(0.12 0.016 250 / 0.6), transparent 55%);
   background-size: 24px 24px, auto, auto;
 }
 


### PR DESCRIPTION
## Problem

Reported by a player solving the [Acyclic Shadows](https://lego-puzzle-editor.vercel.app/puzzle/3d-orthogonal-closed-path-without-cycles-in-any-orthogonal-projection) plugin puzzle: the rendered background was *very* dark, making the shadow walls (and, more generally, every puzzle's board/pieces) hard to see. The darkness was confirmed to affect **all** puzzle types, not just that one — it's the shared rendering/background config.

## Root cause

There are two independent "background" systems and both were set to a near-black navy:

| Surface | Used by | Before | After |
|---|---|---|---|
| `scene.background` + floor grid + fog (`sceneConfig.ts`) | **3D** puzzles | `#0c111b` (oklch L≈0.18) | `#222a3a` (L≈0.29) |
| `.play-stage` CSS base (`index.css`) | **2D** + **plugin** puzzles | `--surface-sunken` (oklch L≈0.09) | `oklch(0.24 0.024 250)` (L≈0.24) |

Plugin puzzles looked *especially* dark because their WebGL canvas is `alpha: true` and floats directly on the (darker) `.play-stage`; 2D puzzles render transparently on the same stage.

## Changes

- **`src/config/sceneConfig.ts`** — `SCENE_3D.background.color` and `fog.color` → `#222a3a` (drives the 3D scene clear color, the floor grid plane, and fog).
- **`src/components/3d/PuzzleScene.tsx`** — canvas wrapper fallback color `#0f1520` → `#222a3a` (avoids a dark flash before the canvas fades in).
- **`src/index.css`** — `.play-stage` base lifted to `oklch(0.24 0.024 250)`, with a stronger center spotlight and a gentler bottom vignette so it doesn't go flat.

Both systems now sit at a consistent medium-dark navy, kept within the "Night Baseplate" design language. A nice side effect for the reported puzzle: the semi-transparent shadow walls now read as distinct darker panels against the brighter stage.

## Notes

- `SCENE_2D.colors.background` / `backgroundEdge` and `COLORS.background` are dead/unused config (the 2D board floats transparent on `.play-stage`), so they were left untouched.
- No functional/logic changes — purely visual color values.

## Verification

Verified the oklch lightness math (before/after L values above). Visual check pending — couldn't drive the browser in this environment. Recommend eyeballing a 3D, a 2D, and the plugin puzzle on a preview deploy; brightness is a one-line nudge in each spot if it needs tuning.